### PR TITLE
Fixed a bug related to sanitizing branch names.

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -140,7 +140,7 @@ def sanitize_name(name,what="branch"):
   n=name
   p=re.compile('([[ ~^:?*]|\.\.)')
   n=p.sub('_', n)
-  if n[-1] == '/': n=n[:-1]+'_'
+  if n[-1] in ('/', '.'): n=n[:-1]+'_'
   n='/'.join(map(dot,n.split('/')))
   p=re.compile('_+')
   n=p.sub('_', n)


### PR DESCRIPTION
Rule #7 of git-check-ref-format states "7. They cannot end with a dot
'.'." which was not yet implemented in fast-export. This commit fixes
this.

I stumbled upon this while converting some of my own hg repositories.
