### PR TITLE
Make hg-fast-export work on Windows

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -23,9 +23,9 @@ def gitmode(flags):
   return 'l' in flags and '120000' or 'x' in flags and '100755' or '100644'
 
 def wr(msg=''):
-  if msg == None:
-    msg = ''
-  print msg
+  if msg:
+    sys.stdout.write(msg)
+  sys.stdout.write('\n')
   #map(lambda x: sys.stderr.write('\t[%s]\n' % x),msg.split('\n'))
 
 def checkpoint(count):

--- a/hg2git.py
+++ b/hg2git.py
@@ -102,7 +102,7 @@ def save_cache(filename,cache):
 def get_git_sha1(name,type='heads'):
   try:
     # use git-rev-parse to support packed refs
-    cmd="GIT_DIR='%s' git rev-parse --verify refs/%s/%s 2>/dev/null" % (os.getenv('GIT_DIR','/dev/null'),type,name)
+    cmd="git rev-parse --verify refs/%s/%s 2>%s" % (type,name,os.devnull)
     p=os.popen(cmd)
     l=p.readline()
     p.close()


### PR DESCRIPTION
This is a simple patch that makes hg-fast-export work on Windows, but doesn't use any fancy Windows-specific code.  The only changes are:
- instead of print, use sys.stdout.write with explicit end-of-line characters to avoid line-terminator issues
- instead of hard-coding /dev/null, use os.devnull

I have successfully used hg-fast-export on Windows with these changes to create a git mirror of the Python Mercurial repository.

This change should also allow issue #3 to be closed.
