### PR TITLE
Fix for Mercurial 2.3 compatibility

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -3,10 +3,9 @@
 # Copyright (c) 2007, 2008 Rocco Rutte <pdmef@gmx.net> and others.
 # License: MIT <http://www.opensource.org/licenses/mit-license.php>
 
-from mercurial import repo,hg,cmdutil,util,ui,revlog,node
+from mercurial import node
 from hg2git import setup_repo,fixup_user,get_branch,get_changeset
 from hg2git import load_cache,save_cache,get_git_sha1,set_default_branch,set_origin_name
-from tempfile import mkstemp
 from optparse import OptionParser
 import re
 import sys

--- a/hg-reset.py
+++ b/hg-reset.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2007, 2008 Rocco Rutte <pdmef@gmx.net> and others.
 # License: GPLv2
 
-from mercurial import repo,hg,cmdutil,util,ui,revlog,node
+from mercurial import node
 from hg2git import setup_repo,load_cache,get_changeset,get_git_sha1
 from optparse import OptionParser
 import sys

--- a/hg2git.py
+++ b/hg2git.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2007, 2008 Rocco Rutte <pdmef@gmx.net> and others.
 # License: MIT <http://www.opensource.org/licenses/mit-license.php>
 
-from mercurial import repo,hg,cmdutil,util,ui,revlog,node,templatefilters
+from mercurial import hg,util,ui,templatefilters
 import re
 import os
 import sys

--- a/svn-fast-export.py
+++ b/svn-fast-export.py
@@ -15,11 +15,11 @@ tags_path = '/tags/'
 first_rev = 1
 final_rev = 0
 
-import gc, sys, os.path
+import sys, os.path
 from optparse import OptionParser
-from time import sleep, mktime, localtime, strftime, strptime
-from svn.fs import svn_fs_dir_entries, svn_fs_file_length, svn_fs_file_contents, svn_fs_is_dir, svn_fs_revision_root, svn_fs_youngest_rev, svn_fs_revision_proplist, svn_fs_revision_prop, svn_fs_paths_changed
-from svn.core import svn_pool_create, svn_pool_clear, svn_pool_destroy, svn_stream_read, svn_stream_for_stdout, svn_stream_copy, svn_stream_close, run_app
+from time import mktime, strptime
+from svn.fs import svn_fs_file_length, svn_fs_file_contents, svn_fs_is_dir, svn_fs_revision_root, svn_fs_youngest_rev, svn_fs_revision_proplist, svn_fs_paths_changed
+from svn.core import svn_pool_create, svn_pool_clear, svn_pool_destroy, svn_stream_for_stdout, svn_stream_copy, svn_stream_close, run_app
 from svn.repos import svn_repos_open, svn_repos_fs
 
 ct_short = ['M', 'A', 'D', 'R', 'X']


### PR DESCRIPTION
After an update to Mercurial 2.3 the module 'repo' was removed and the
program crashed when trying to convert a repository. I checked the
imports with 'pyflakes' and removed all unused ones, repo (among
others) was never used.

Changelog of mercurial
http://www.selenic.com/repo/hg/rev/1ac628cd7113#l9.1
