### PR TITLE
Make Windows support actually work

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -11,6 +11,14 @@ import re
 import sys
 import os
 
+if sys.platform == "win32":
+  # On Windows, sys.stdout is initially opened in text mode, which means that
+  # when a LF (\n) character is written to sys.stdout, it will be converted
+  # into CRLF (\r\n).  That makes git blow up, so use this platform-specific
+  # code to change the mode of sys.stdout to binary.
+  import msvcrt
+  msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
+
 # silly regex to catch Signed-off-by lines in log message
 sob_re=re.compile('^Signed-[Oo]ff-[Bb]y: (.+)$')
 # insert 'checkpoint' command after this many commits or none at all if 0


### PR DESCRIPTION
My previous change to use sys.stdout.write instead of print didn't actually make any difference, because the transformation of LF to CRLF happens regardless of which way the LF characters are written.  The only way I have found to actually make sys.stdout use binary mode is via the code posted by @dimo3d in issue #3.  (I've tried doing a fdopen on sys.stdout to reopen it in binary mode but without success.)

This change implements that functionality for Windows.  I have used this change in conjunction with git-hg to import the entire Python Mercurial repository into Git.
