### PR TITLE
checking for - and converting - backslashes

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -145,7 +145,7 @@ def sanitize_name(name,what="branch"):
     return name
 
   n=name
-  p=re.compile('([[ ~^:?*]|\.\.)')
+  p=re.compile('([[ ~^:?\\\\*]|\.\.)')
   n=p.sub('_', n)
   if n[-1] in ('/', '.'): n=n[:-1]+'_'
   n='/'.join(map(dot,n.split('/')))


### PR DESCRIPTION
Converting the backslash character (`\`) to an underscore (`_`) just like the other bad characters.

Four backslashes because Python AND regex require the backslash to be escaped appropriately.
