### PR TITLE
Removing line returns from branch/tag names

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -145,7 +145,7 @@ def sanitize_name(name,what="branch"):
     return name
 
   n=name
-  p=re.compile('([[ ~^:?\\\\*]|\.\.)')
+  p=re.compile('([[~^:?\\\\\\s*]|\.\.)')
   n=p.sub('_', n)
   if n[-1] in ('/', '.'): n=n[:-1]+'_'
   n='/'.join(map(dot,n.split('/')))


### PR DESCRIPTION
Encountered a bug in SourceTree where it will allow a user to copy/paste 2 lines of copy and create a branch from it. This results in the following:

```
branch with a
line break
```

Mercurial does not allow this via Command Line, so SourceTree must be doing something behind-the-scenes to convert this into an acceptable branch.

**Solution**
Removing the space from the regex and putting in it's place `\s` which will remove any whitespace, tab character or line break.

**Resolved Output**

```
Warning: sanitized branch [branch_name_on
multiple_lines] to [branch_name_on_multiple_lines]
```
