### PR TITLE
Fix ROOT if hg-fast-export is in PATH

### DIFF
--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2007, 2008 Rocco Rutte <pdmef@gmx.net> and others.
 # License: MIT <http://www.opensource.org/licenses/mit-license.php>
 
-ROOT="`dirname "$0"`"
+ROOT="`dirname "$(type -p $0)"`"
 REPO=""
 PFX="hg2git"
 SFX_MAPPING="mapping"


### PR DESCRIPTION
dirname $0 will return "." if hg-fast-export, which will make hg-fast-export.py not to be found.
