### PR TITLE
Additional validation for branch names.

### DIFF
--- a/README-SUBMODULES.md
+++ b/README-SUBMODULES.md
@@ -2,31 +2,45 @@
 
 **WARNING: This will only work on Linux/MAC or Windows with cygwin**
 
-First you have to convert the sub repository to git using directory of sub repo in main repo for -r parameter of
-hg-fast-expert.sh.
+## Requirements
+
+Please install all the software requirements listed in the
+`requirements-submodules.txt` file by running
+
+```
+pip install -r requirements-submodules.txt
+```
+
+Ideally, do that within a [virtualenv][venv] to isolate these from other Python
+packages you may or may not have already installed on your system.
 
 ## Convertion example
-e.g. if you main repo is in directory `/srv/projects/hg-main-repo` and the sub directory `subrepo` is a subrepo of your
-main repository then convert the whole repo with...
 
-### sub repository
+First you have to convert the sub repository to git using the directory of sub
+repo in main repo for -r parameter of hg-fast-expert.sh.
+
+E.g. if you main repo is in directory `/srv/projects/hg-main-repo` and the sub
+directory `subrepo` is a subrepo of your main repository then convert the whole
+repo with...
+
+### Sub repository
 
     cd /srv/projects
     mkdir git-subrepo
     cd git-subrepo
     git init
-    /path/to/fast-export//hg-fast-export.sh -r /srv/projects/hg-main-repo/subrepo
+    /path/to/fast-export/hg-fast-export.sh -r /srv/projects/hg-main-repo/subrepo
 
     git co HEAD
     git remote add origin git@server/repo
     git push origin --all
 
-### main repository
+### Main repository
 
     cd /srv/projects
     mkdir git-main-repo
     cd git-main-repo
-    git init /path/to/fast-export//hg-fast-export.sh -r /srv/projects/hg-main-repo
+    git init /path/to/fast-export/hg-fast-export.sh -r /srv/projects/hg-main-repo
 
     git co HEAD
     git submodule init
@@ -35,11 +49,13 @@ main repository then convert the whole repo with...
 
 ## Sub repository is used in more than one repository
 
-Its not necessary to convert the subrepo every time convertig a main repository. If you want to use an already converted
-subrepo copy only one file from the converted subrepo to the new one.
+It's not necessary to convert the subrepo every time you want to convert the
+main repository. Once you have converted a sub-repository once, copy the
+`.hg/link2git` file into the sub-repository of any other repository.
 
-e.g. if you main repo is in directory `/srv/projects/hg-main-repo2` and the sub directory `subrepo` is a subrepo of your
-main repository then convert th whole repo with...
+E.g. if you main repo is in directory `/srv/projects/hg-main-repo2` and the sub
+directory `subrepo` is a subrepo of your main repository then convert the whole
+repo with...
 
     cp /srv/projects/hg-main-repo/subrepo/.hg/link2git /srv/projects/hg-main-repo2/subrepo/.hg/.
 
@@ -51,3 +67,6 @@ main repository then convert th whole repo with...
     git co HEAD
     git submodule init
     git submodule update
+
+
+[venv]: http://docs.python-guide.org/en/latest/dev/virtualenvs/#virtualenv

--- a/README-SUBMODULES.md
+++ b/README-SUBMODULES.md
@@ -23,6 +23,11 @@ E.g. if you main repo is in directory `/srv/projects/hg-main-repo` and the sub
 directory `subrepo` is a subrepo of your main repository then convert the whole
 repo with...
 
+### Optional usefull parameters
+* ```--ignore-subrepos```: If the repository contains subrepos, ignore it -> ends in empty sub repo directories.
+This is useful if you had subrepos but not actual and dont care about the history.
+* ```--fix-branchnames```: If the branch name contains strange characters - remove it
+
 ### Sub repository
 
     cd /srv/projects

--- a/README-SUBMODULES.md
+++ b/README-SUBMODULES.md
@@ -1,0 +1,53 @@
+# How to convert Mercurial Repositories with subrepos
+
+**WARNING: This will only work on Linux/MAC or Windows with cygwin**
+
+First you have to convert the sub repository to git using directory of sub repo in main repo for -r parameter of
+hg-fast-expert.sh.
+
+## Convertion example
+e.g. if you main repo is in directory `/srv/projects/hg-main-repo` and the sub directory `subrepo` is a subrepo of your
+main repository then convert the whole repo with...
+
+### sub repository
+
+    cd /srv/projects
+    mkdir git-subrepo
+    cd git-subrepo
+    git init
+    /path/to/fast-export//hg-fast-export.sh -r /srv/projects/hg-main-repo/subrepo
+
+    git co HEAD
+    git remote add origin git@server/repo
+    git push origin --all
+
+### main repository
+
+    cd /srv/projects
+    mkdir git-main-repo
+    cd git-main-repo
+    git init /path/to/fast-export//hg-fast-export.sh -r /srv/projects/hg-main-repo
+
+    git co HEAD
+    git submodule init
+    git submodule update
+
+
+## Sub repository is used in more than one repository
+
+Its not necessary to convert the subrepo every time convertig a main repository. If you want to use an already converted
+subrepo copy only one file from the converted subrepo to the new one.
+
+e.g. if you main repo is in directory `/srv/projects/hg-main-repo2` and the sub directory `subrepo` is a subrepo of your
+main repository then convert th whole repo with...
+
+    cp /srv/projects/hg-main-repo/subrepo/.hg/link2git /srv/projects/hg-main-repo2/subrepo/.hg/.
+
+    cd /srv/projects
+    mkdir git-main-repo2
+    cd git-main-repo2
+    git init /path/to/fast-export//hg-fast-export.sh -r /srv/projects/hg-main-repo2
+
+    git co HEAD
+    git submodule init
+    git submodule update

--- a/fast-export-submodule
+++ b/fast-export-submodule
@@ -1,0 +1,20 @@
+blob
+mark :1
+data 81
+[submodule "parent"]
+	path = parent
+	url = git@scm.apogeum.at:apogeum/parent.git
+
+reset refs/heads/master
+commit refs/heads/master
+mark :2
+author Stephan Bechter <stephan@apogeum.at> 1413745181 +0200
+committer Stephan Bechter <stephan@apogeum.at> 1413745181 +0200
+data 16
+added submodule
+M 100644 :1 .gitmodules
+M 160000 1fae593d9567113137921d6baa47da6de6b3a0e2 parent
+
+reset refs/heads/master
+from :2
+

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -125,7 +125,7 @@ def get_author(logmessage,committer,authors):
       return r
   return committer
 
-def export_file_contents(ctx,manifest,files,hgtags,encoding='',repourl,revnode):
+def export_file_contents(ctx,manifest,files,hgtags,repourl,revnode,encoding=''):
   count=0
   max=len(files)
   for file in files:
@@ -200,7 +200,7 @@ def sanitize_name(name,what="branch"):
     sys.stderr.write('Warning: sanitized %s [%s] to [%s]\n' % (what,name,n))
   return n
 
-def export_commit(ui,repo,revision,old_marks,max,count,authors,sob,brmap,hgtags,notes,encoding='',repourl):
+def export_commit(ui,repo,revision,old_marks,max,count,authors,sob,brmap,hgtags,notes,repourl,encoding=''):
   def get_branchname(name):
     if brmap.has_key(name):
       return brmap[name]
@@ -259,8 +259,8 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,sob,brmap,hgtags,
     removed=[r.decode(encoding).encode('utf8') for r in removed]
 
   map(lambda r: wr('D %s' % r),removed)
-  export_file_contents(ctx,man,added,hgtags,encoding,repourl,revnode)
-  export_file_contents(ctx,man,changed,hgtags,encoding,repourl,revnode)
+  export_file_contents(ctx,man,added,hgtags,repourl,revnode,encoding)
+  export_file_contents(ctx,man,changed,hgtags,repourl,revnode,encoding)
   wr()
 
   count=checkpoint(count)
@@ -426,7 +426,7 @@ def hg2git(repourl,m,marksfile,mappingfile,headsfile,tipfile,authors={},sob=Fals
   c=0
   brmap={}
   for rev in range(min,max):
-    c=export_commit(ui,repo,rev,old_marks,max,c,authors,sob,brmap,hgtags,notes,encoding,repourl)
+    c=export_commit(ui,repo,rev,old_marks,max,c,authors,sob,brmap,hgtags,notes,repourl,encoding)
 
   state_cache['tip']=max
   state_cache['repo']=repourl

--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -13,7 +13,7 @@ SFX_STATE="state"
 GFI_OPTS=""
 PYTHON=${PYTHON:-python}
 
-USAGE="[--quiet] [-r <repo>] [--force] [-m <max>] [-s] [--hgtags] [-A <file>] [-M <name>] [-o <name>] [--hg-hash] [-e <encoding>]"
+USAGE="[--quiet] [-r <repo>] [--force] [-m <max>] [-s] [--hgtags] [-A <file>] [-M <name>] [-o <name>] [--hg-hash] [-e <encoding>] [--ignore-subrepos]"
 LONG_USAGE="Import hg repository <repo> up to either tip or <max>
 If <repo> is omitted, use last hg repository as obtained from state file,
 GIT_DIR/$PFX-$SFX_STATE by default.
@@ -34,8 +34,10 @@ Options:
 	-o <name> Use <name> as branch namespace to track upstream (eg 'origin')
 	--hg-hash Annotate commits with the hg hash as git notes in the
                   hg namespace.
-	-e <encoding> Assume commit and author strings retrieved from 
+	-e <encoding> Assume commit and author strings retrieved from
 	              Mercurial are encoded in <encoding>
+	--ignore-subrepos   Ignore sub repositories, and pass --force
+	          to hg-fast-export(1)
 "
 case "$1" in
     -h|--help)

--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -137,5 +137,19 @@ for head in `git branch | sed 's#^..##'` ; do
   echo ":$head $id"
 done > "$GIT_DIR/$PFX-$SFX_HEADS"
 
+# create mapping file from hg revision to git revision
+sed 's/^://g' .git/hg2git-mapping | awk '{print ":"$2" "$1}' | sort | sed 's/[0-9]* //g' > .git/mappingsTemp
+sort .git/hg2git-marks | sed 's/^:[0-9]* //g' > .git/marksTemp
+paste -d ' ' .git/mappingsTemp .git/marksTemp > $GIT_DIR/$PFX-revisions
+rm  .git/mappingsTemp .git/marksTemp
+
 # check diff with color:
 # ( for i in `find . -type f | grep -v '\.git'` ; do diff -u $i $REPO/$i ; done | cdiff ) | less -r
+
+echo
+echo "Checkout your repo using"
+echo "git checkout HEAD"
+echo
+echo "If this repositor contains submodules, then initialize and update the submodules with the following commands."
+echo "git submodule init"
+echo "git submodule update"

--- a/requirements-submodules.txt
+++ b/requirements-submodules.txt
@@ -1,0 +1,5 @@
+GitPython==0.3.2.RC1
+async==0.6.1
+gitdb==0.5.4
+mercurial==3.1.2
+smmap==0.8.2


### PR DESCRIPTION
Must match regex '^[^a-zA-Z0-9\/\.\(\)_-]*([a-zA-Z0-9\/\.\(\)_-]*)' to avoid getting branch names with special characters

Someways it happens that developers created branch names that contains speacial characters. Convertion for this branches fails, so i added this check. (Branch Names will be changed)
