### PR TITLE
Fix dirname detection on Windows systems

### DIFF
--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -3,7 +3,11 @@
 # Copyright (c) 2007, 2008 Rocco Rutte <pdmef@gmx.net> and others.
 # License: MIT <http://www.opensource.org/licenses/mit-license.php>
 
-ROOT="$(dirname "$(which "$0")")"
+# full path to script
+SCRIPT="$(which "$0")"
+# replace all "\" with "/"
+SCRIPT="${SCRIPT//\\//}"
+ROOT="$(dirname "$SCRIPT")"
 REPO=""
 PFX="hg2git"
 SFX_MAPPING="mapping"


### PR DESCRIPTION
On Windows systems function `dirname` fails and always return `.`
This fix replace all Windows backslashes `\` to Unix forward slashes `/` in script path, so `dirname` return proper dir.
