### PR TITLE
Crude fix - handle multiple lt or gt in author line

### DIFF
--- a/hg2git.py
+++ b/hg2git.py
@@ -52,6 +52,14 @@ def fixup_user(user,authors):
     # if we have 'Name <mail>' syntax, everything is fine :)
     name,mail=m.group(1),m.group(2)
 
+
+  # remove duplicated < or > - this causes fatals
+  double_ltgt = ['<<', '>>']
+
+  for dupe in double_ltgt:
+    if dupe in mail:
+      mail.replace(dupe, dupe[0])
+
   # remove any silly quoting from username
   m2=user_clean_re.match(name)
   if m2!=None:


### PR DESCRIPTION
I hit the scenario where a fatal was thrown by git because of a user having multiple lt symbols in their author config, I didn't have much time to trace this through, as had a big project that I needed to convert from hg to git, so excuse the crudeness of my patch, it basically prevents fast-export from choking on:

```
* Some Dude <<some@dude.com>
* Other Dude <some@otherdude.co>>
* Another Dude <<another@dude.com>>
```