### PR TITLE
Resolve empty Mercurial authors

### DIFF
--- a/hg2git.py
+++ b/hg2git.py
@@ -35,10 +35,12 @@ def setup_repo(url):
 
 def fixup_user(user,authors):
   user=user.strip("\"")
+  
   if authors!=None:
     # if we have an authors table, try to get mapping
     # by defaulting to the current value of 'user'
     user=authors.get(user,user)
+
   name,mail,m='','',user_re.match(user)
   if m==None:
     # if we don't have 'Name <mail>' syntax, extract name
@@ -56,6 +58,10 @@ def fixup_user(user,authors):
   m2=user_clean_re.match(name)
   if m2!=None:
     name=m2.group(1)
+
+  if name=='' or name==None or name=='<>':
+    name='Unknown User'
+    
   return '%s %s' % (name,mail)
 
 def get_branch(name):


### PR DESCRIPTION
We ran into a crash condition where an empty Mercurial commit author could not be handled.  This resulted in the string "[devnull@localhost] [time] [tz]" being used as the input for git raw date parsing, throwing an invalid argument error.

Attempts were made to resolve the empty author through a number of authors mapping file entries, none of which worked.  Last resort was to include a blank author check in the hg2git.py and supply a default value.
