### PR TITLE
Add filename encoding option --fe

### DIFF
--- a/README
+++ b/README
@@ -37,7 +37,11 @@ again.
 When a mercurial repository does not use utf-8 for encoding author
 strings and commit messages the "-e <encoding>" command line option
 can be used to force fast-export to convert incoming meta data from
-<encoding> to utf-8.
+<encoding> to utf-8. This encoding option is also applied to file names.
+
+In some locales Mercurial uses different encodings for commit messages
+and file names. In that case, you can use "--fe <encoding>" command line
+option which overrides the -e option for file names.
 
 As mercurial appears to be much less picky about the syntax of the
 author information than git, an author mapping file can be given to

--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -38,6 +38,8 @@ Options:
                   hg namespace.
 	-e <encoding> Assume commit and author strings retrieved from 
 	              Mercurial are encoded in <encoding>
+	--fe <filename_encoding> Assume filenames from Mercurial are encoded 
+	                         in <filename_encoding>
 "
 case "$1" in
     -h|--help)


### PR DESCRIPTION
This encoding option is applied to only file names.

In my locale, default setting of Mercurial Windows version, can use two encoding for commit message and file names. Usually UTF-8 encoding for commit message and EUC-KR for file names.

This option (--fe) specifies the encoding only for file names.
