### PR TITLE
Fix PATH when using git >= 2.10

### DIFF
--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -48,7 +48,8 @@ case "$1" in
       echo "$LONG_USAGE"
       exit 0
 esac
-. "$(git --exec-path)/git-sh-setup"
+git_exec_path="$(git --exec-path)"
+PATH="$PATH:$git_exec_path" . "$git_exec_path/git-sh-setup"
 cd_to_toplevel
 
 while case "$#" in 0) break ;; esac

--- a/hg-reset.sh
+++ b/hg-reset.sh
@@ -24,7 +24,8 @@ Options:
 	-r	Mercurial repository to use
 "
 
-. "$(git --exec-path)/git-sh-setup"
+git_exec_path="$(git --exec-path)"
+PATH="$PATH:$git_exec_path" . "$git_exec_path/git-sh-setup"
 cd_to_toplevel
 
 while case "$#" in 0) break ;; esac


### PR DESCRIPTION
Since [this commit](https://github.com/git/git/commit/d323c6b6410dee0a8a2471b4dbf6d631cd3c3d4d), `git-sh-setup.sh` tries to source files in its exec path which is not
usually included in PATH.

Let me know if this is the right way to fix the issue. Without this workaround, the shell scripts fail with:
```
/usr/libexec/git-core/git-sh-setup: line 6: .: git-sh-i18n: file not found
```