### PR TITLE
make annotated tags, not weak tags

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -287,8 +287,11 @@ def export_tags(ui,repo,old_marks,mapping_cache,count,authors,tagsmap):
           ' %s at r%d\n' % (tag,rev))
       continue
     sys.stderr.write('Exporting tag [%s] at [hg r%d] [git %s]\n' % (tag,rev,ref))
-    wr('reset refs/tags/%s' % tag)
+    wr('tag %s' % tag)
     wr('from %s' % ref)
+    (_,_,user,(time,timezone),_,_,_,_)=get_changeset(ui,repo,rev,authors)
+    wr('tagger %s %d %s' % (user,time,timezone))
+    wr('data 0')
     wr()
     count=checkpoint(count)
   return count


### PR DESCRIPTION
It seems that hg has some meta info about a tag anyway: the tagger and date, which is different from the previous commit that is being tagged. It could be saved correctly in git in an annotated tag object.

Nevertheless, the message is empty according to this patch.
