### PR TITLE
Make hg-fst-export.sh callable via a symbolic link

### DIFF
--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -3,7 +3,11 @@
 # Copyright (c) 2007, 2008 Rocco Rutte <pdmef@gmx.net> and others.
 # License: MIT <http://www.opensource.org/licenses/mit-license.php>
 
-ROOT="$(dirname "$(which "$0")")"
+READLINK="readlink"
+if command -v greadlink > /dev/null; then
+  READLINK="greadlink" # Prefer greadlink over readlink
+fi
+ROOT="$(dirname "$($READLINK -f "$(which "$0")")")"
 REPO=""
 PFX="hg2git"
 SFX_MAPPING="mapping"


### PR DESCRIPTION
Calling hg-fast-export.sh via symlink used to fail because
the script would look for hg-fast-export.py in symlink‘s
folder. This patch adds symlink resolution using readlink and
greadlink with fallback to support MacOs. That way you can
safely add a symlink to hg-fast-export.sh somewhere in you PATH.

Fixes https://github.com/frej/fast-export/issues/93