### PR TITLE
Filter file contents, Was: Suggestion: add --as-binary option to convert line endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,27 @@ name the -B and -T options allow a mapping file to be specified to
 rename branches and tags (respectively). The syntax of the mapping
 file is the same as for the author mapping.
 
+Content filtering
+-----------------
+
+hg-fast-export supports filtering the content of exported files.
+The filter is supplied to the --filter-contents option. hg-fast-export
+runs the filter for each exported file, pipes its content to the filter's
+standard input, and uses the filter's standard output in place
+of the file's original content. The prototypical use of this feature
+is to convert line endings in text files from CRLF to git's preferred LF:
+
+```
+-- Start of crlf-filter.sh --
+#!/bin/sh
+# $1 = pathname of exported file relative to the root of the repo
+# $2 = Mercurial's hash of the file
+# $3 = "1" if Mercurial reports the file as binary, otherwise "0"
+
+if [ "$3" == "1" ]; then cat; else dos2unix; fi
+-- End of crlf-filter.sh --
+```
+
 Notes/Limitations
 -----------------
 

--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -56,6 +56,8 @@ Options:
 	--fe <filename_encoding> Assume filenames from Mercurial are encoded 
 	                         in <filename_encoding>
 	--mappings-are-raw Assume mappings are raw <key>=<value> lines
+	--filter-contents <cmd>  Pipe contents of each exported file through <cmd>
+	                         with <file-path> <hg-hash> <is-binary> as arguments
 "
 case "$1" in
     -h|--help)


### PR DESCRIPTION
Converting line endings in text files to LF is often needed when migrating from Mercurial to Git. Right now it is usually done by git filter-branch and other heavy-weight approaches, but it is very easy to do in fast-export provided that binary files have distinct filenames (e.g. distinct extensions). This change adds an option `--as-binary` that turns on auto-conversion of line endings to LF and takes a list of binary file extensions, e.g. `hg-fast-export ..\repo --as-binary=.so,.dll`. As an implementation side-effect, dot-files (e.g. `.hgignore`) are treated as text.