### PR TITLE
Do not stop processing options after --force

### DIFF
--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -12,6 +12,7 @@ SFX_HEADS="heads"
 SFX_STATE="state"
 GFI_OPTS=""
 PYTHON=${PYTHON:-python}
+FORCE=0
 
 USAGE="[--quiet] [-r <repo>] [--force] [-m <max>] [-s] [--hgtags] [-A <file>] [-B <file>] [-T <file>] [-M <name>] [-o <name>] [--hg-hash] [-e <encoding>]"
 LONG_USAGE="Import hg repository <repo> up to either tip or <max>
@@ -81,6 +82,7 @@ do
       # pass --force to git-fast-import and hg-fast-export.py
       GFI_OPTS="$GFI_OPTS --force"
       IGNORECASEWARN="";
+      FORCE=1
       ;;
     -*)
       # pass any other options down to hg2git.py
@@ -128,6 +130,19 @@ fi
 # cleanup on exit
 trap 'rm -f "$GIT_DIR/$PFX-$SFX_MARKS.old" "$GIT_DIR/$PFX-$SFX_MARKS.tmp"' 0
 
+#
+# Setup arguments for python code to handle --force properly
+#
+PY_ARGS="$@"
+
+if [ $FORCE == 1 ]; then
+  if [ -z "$@" ]; then
+    PY_ARGS="--force"
+  else
+    PY_ARGS="--force $@"
+  fi
+fi
+
 _err1=
 _err2=
 exec 3>&1
@@ -142,7 +157,7 @@ $(
       --mapping "$GIT_DIR/$PFX-$SFX_MAPPING" \
       --heads "$GIT_DIR/$PFX-$SFX_HEADS" \
       --status "$GIT_DIR/$PFX-$SFX_STATE" \
-      "$@" 3>&- || _e1=$?
+      "$PY_ARGS" 3>&- || _e1=$?
     echo $_e1 >&3
   } | \
   {

--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -67,7 +67,7 @@ if [ "true" = "$IGNORECASE" ]; then
 fi;
 
 
-while case "$#" in 0) break ;; esac
+while [ $# -gt 0 ]
 do
   case "$1" in
     -r|--r|--re|--rep|--repo)
@@ -81,7 +81,6 @@ do
       # pass --force to git-fast-import and hg-fast-export.py
       GFI_OPTS="$GFI_OPTS --force"
       IGNORECASEWARN="";
-      break
       ;;
     -*)
       # pass any other options down to hg2git.py


### PR DESCRIPTION
This is a fix for issue   #57  when run as:

`./hg-fast-export.sh --force -r path-to-hg-repo`

The -r option and it's argument are ignored resulting in an error