### PR TITLE
Fixed problem with line feed in branch name

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -169,6 +169,9 @@ def sanitize_name(name,what="branch", mapping={}):
   n='/'.join(map(dot,n.split('/')))
   p=re.compile('_+')
   n=p.sub('_', n)
+  
+  n = n.replace("\n", "")
+  n = n.replace("\r", "")
 
   if n!=name:
     sys.stderr.write('Warning: sanitized %s [%s] to [%s]\n' % (what,name,n))


### PR DESCRIPTION
My hg repo included a repo with a line feed in the branch name, which caused hg-fast-export.py to crash. I've added a fix - although my regex skills are not good enough to make it fit neatly with your solution.
