### PR TITLE
sanitize hg branch /name => root/name

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -170,6 +170,9 @@ def sanitize_name(name,what="branch", mapping={}):
   p=re.compile('_+')
   n=p.sub('_', n)
 
+  if n[0] == '/':
+    n='root'+n
+  
   if n!=name:
     sys.stderr.write('Warning: sanitized %s [%s] to [%s]\n' % (what,name,n))
   return n


### PR DESCRIPTION
Git rejects branch names with leading slash.  This pr converts `/branch_name` to `root/branch_name`.