### PR TITLE
Replace \ and / with _ in branch names to avoid errors when exporting…

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -196,6 +196,12 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
 
   branch=get_branchname(branch)
 
+  if "/" in branch:
+    branch=branch.replace("/", "_")
+	
+  if "\\" in branch:
+    branch=branch.replace("\\", "_")
+  
   parents = [p for p in repo.changelog.parentrevs(revision) if p >= 0]
 
   if len(parents)==0 and revision != 0:


### PR DESCRIPTION
… sub branches when parent branch exists.

Solves issue when you have branch named x and sub branches named x/y.
Before, it would create a file for x and when encountered sub branch under x would try to create x as directory, obviously failing because it already exists as file.

This replaces both type of slashes to underscore and was the only thing I could do to export a huge repo with lots of badly named branches.