### PR TITLE
AttributeError: 'module' object has no attribute 'email'

### DIFF
--- a/hg2git.py
+++ b/hg2git.py
@@ -49,7 +49,7 @@ def fixup_user(user,authors):
     # and mail from hg helpers. this seems to work pretty well.
     # if email doesn't contain @, replace it with devnull@localhost
     name=templatefilters.person(user)
-    mail='<%s>' % util.email(user)
+    mail='<%s>' % templatefilters.email(user)
     if '@' not in mail:
       mail = '<devnull@localhost>'
   else:


### PR DESCRIPTION
Fixes #137. 
Mercurial **4.7**
This PR replaces call to missing attribute `util.email` with `templatefilters.email`. 

Thanks