### PR TITLE
Plugin System

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+*.orig
 *.pyc
 .dotest
+.idea/

--- a/README.md
+++ b/README.md
@@ -120,6 +120,54 @@ if [ "$3" == "1" ]; then cat; else dos2unix; fi
 -- End of crlf-filter.sh --
 ```
 
+
+Plugins
+-----------------
+
+hg-fast-export supports plugins to manipulate the file data and commit
+metadata. The plugins are enabled with the --plugin option. The value
+of said option is a plugin name (by folder in the plugins directory),
+and optionally, and equals-sign followed by an initialization string.
+
+There is a readme accompanying each of the bundled plugins, with a
+description of the usage. To create a new plugin, one must simply
+add a new folder under the `plugins` directory, with the name of the
+new plugin. Inside, there must be an `__init__.py` file, which contains
+at a minimum:
+
+```
+def build_filter(args):
+    return Filter(args)
+
+class Filter:
+    def __init__(self, args):
+        pass
+        #Or don't pass, if you want to do some init code here
+```
+
+
+```
+commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc}
+
+def commit_message_filter(self,commit_data):
+```
+The `commit_message_filter` method is called for each commit, after parsing
+from hg, but before outputting to git. The dictionary `commit_data` contains the
+above attributes about the commit, and can be modified by any filter. The
+values in the dictionary after filters have been run are used to create the git
+commit.
+
+```
+file_data = {'filename':filename,'file_ctx':file_ctx,'d':d}
+
+def file_data_filter(self,file_data):
+```
+The `file_data_filter` method is called for each file within each commit.
+The dictionary `file_data` contains the above attributes about the file, and
+can be modified by any filter. `file_ctx` is the filecontext from the
+mercurial python library.  After all filters have been run, the values
+are used to add the file to the git commit.
+
 Notes/Limitations
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ class Filter:
         #Or don't pass, if you want to do some init code here
 ```
 
+Beyond the boilerplate initialization, you can see the one of the
+defined filter methods in the [dos2unix](./plugins/dos2unix) plugin.
 
 ```
 commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc}

--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ class Filter:
         #Or don't pass, if you want to do some init code here
 ```
 
-Beyond the boilerplate initialization, you can see the one of the
-defined filter methods in the [dos2unix](./plugins/dos2unix) plugin.
+Beyond the boilerplate initialization, you can see the two different
+defined filter methods in the [dos2unix](./plugins/dos2unix) and
+[branch_name_in_commit](./plugins/branch_name_in_commit) plugins.
 
 ```
 commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc}

--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -58,6 +58,8 @@ Options:
 	--mappings-are-raw Assume mappings are raw <key>=<value> lines
 	--filter-contents <cmd>  Pipe contents of each exported file through <cmd>
 	                         with <file-path> <hg-hash> <is-binary> as arguments
+	--plugin <plugin=init>  Add a plugin with the given init string (repeatable)
+	--plugin-path <plugin-path> Add an additional plugin lookup path
 "
 case "$1" in
     -h|--help)

--- a/pluginloader/__init__.py
+++ b/pluginloader/__init__.py
@@ -1,0 +1,19 @@
+import os
+import imp
+PluginFolder = os.path.join(os.path.dirname(os.path.realpath(__file__)),"..","plugins")
+MainModule = "__init__"
+
+def get_plugin(name, plugin_path):
+    search_dirs = [PluginFolder]
+    if plugin_path:
+        search_dirs = [plugin_path] + search_dirs
+    for dir in search_dirs:
+        location = os.path.join(dir, name)
+        if not os.path.isdir(location) or not MainModule + ".py" in os.listdir(location):
+            continue
+        info = imp.find_module(MainModule, [location])
+        return {"name": name, "info": info, "path": location}
+    raise Exception("Could not find plugin with name " + name)
+
+def load_plugin(plugin):
+    return imp.load_module(MainModule, *plugin["info"])

--- a/plugins/branch_name_in_commit/README.md
+++ b/plugins/branch_name_in_commit/README.md
@@ -1,0 +1,10 @@
+## Branch Name in Commit Message
+
+Mercurial has a much stronger notion of branches than Git,
+and some parties may not wish to lose the branch information
+during the migration to Git. You can use this plugin to either
+prepend or append the branch name from the mercurial
+commit into the commit message in Git.
+
+To use the plugin, add
+`--plugin branch_name_in_commit=(start|end)`.

--- a/plugins/branch_name_in_commit/__init__.py
+++ b/plugins/branch_name_in_commit/__init__.py
@@ -1,0 +1,14 @@
+def build_filter(args):
+    return Filter(args)
+
+class Filter:
+    def __init__(self, args):
+        if not args in ['start','end']:
+            raise Exception('Cannot have branch name anywhere but start and end')
+        self.pos = args
+
+    def commit_message_filter(self,commit_data):
+        if self.pos == 'start':
+            commit_data['desc'] = commit_data['branch'] + '\n' + commit_data['desc']
+        if self.pos == 'end':
+            commit_data['desc'] = commit_data['desc'] + '\n' + commit_data['branch']

--- a/plugins/dos2unix/README.md
+++ b/plugins/dos2unix/README.md
@@ -1,0 +1,9 @@
+## Dos2unix filter
+
+This plugin converts CRLF line ending to LF in text files in the repo.
+It is recommended that you have a .gitattributes file that maintains
+the usage of LF endings going forward, for after you have converted your
+repository.
+
+To use the plugin, add
+`--plugin dos2unix`.

--- a/plugins/dos2unix/__init__.py
+++ b/plugins/dos2unix/__init__.py
@@ -1,0 +1,11 @@
+def build_filter(args):
+    return Filter(args)
+
+class Filter():
+    def __init__(self, args):
+        pass
+
+    def file_data_filter(self,file_data):
+        file_ctx = file_data['file_ctx']
+        if not file_ctx.isbinary():
+            file_data['data'] = file_data['data'].replace('\r\n', '\n')

--- a/plugins/shell_filter_file_contents/README.md
+++ b/plugins/shell_filter_file_contents/README.md
@@ -1,0 +1,30 @@
+## Shell Script File Filter
+
+This plugin uses shell scripts in order to perform filtering of files.
+If your preferred scripting is done via shell, this tool is for you.
+Be noted, though, that this method can cause an order of magnitude slow
+down. For small repositories, this wont be an issue.
+
+To use the plugin, add
+`--plugin shell_filter_file_contents=path/to/shell/script.sh`.
+The filter script is supplied to the plugin option after the plugin name,
+which is in turned passed to the plugin initialization. hg-fast-export
+runs the filter for each exported file, pipes its content to the filter's
+standard input, and uses the filter's standard output in place
+of the file's original content. An example use of this feature
+is to convert line endings in text files from CRLF to git's preferred LF,
+although this task is faster performed using the native plugin.
+
+The script is called with the following syntax:
+`FILTER_CONTENTS <file-path> <hg-hash> <is-binary>`
+
+```
+-- Start of crlf-filter.sh --
+#!/bin/sh
+# $1 = pathname of exported file relative to the root of the repo
+# $2 = Mercurial's hash of the file
+# $3 = "1" if Mercurial reports the file as binary, otherwise "0"
+
+if [ "$3" == "1" ]; then cat; else dos2unix; fi
+-- End of crlf-filter.sh --
+```

--- a/plugins/shell_filter_file_contents/__init__.py
+++ b/plugins/shell_filter_file_contents/__init__.py
@@ -1,0 +1,28 @@
+#Pipe contents of each exported file through FILTER_CONTENTS <file-path> <hg-hash> <is-binary>"
+import subprocess
+import shlex
+import sys
+from mercurial import node
+
+def build_filter(args):
+    return Filter(args)
+
+class Filter:
+    def __init__(self, args):
+        self.filter_contents = shlex.split(args)
+
+    def file_data_filter(self,file_data):
+        d = file_data['data']
+        file_ctx = file_data['file_ctx']
+        filename = file_data['filename']
+        filter_cmd = self.filter_contents + [filename, node.hex(file_ctx.filenode()), '1' if file_ctx.isbinary() else '0']
+        try:
+            filter_proc = subprocess.Popen(filter_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+            d, _ = filter_proc.communicate(d)
+        except:
+            sys.stderr.write('Running filter-contents %s:\n' % filter_cmd)
+            raise
+        filter_ret = filter_proc.poll()
+        if filter_ret:
+            raise subprocess.CalledProcessError(filter_ret, filter_cmd)
+        file_data['data'] = d


### PR DESCRIPTION
Throwing these out there for discussion, before I do any work to potentially isolate them if desired.

After seeing the changes to run a shell script, I tried doing it on a repo with a few hundred thousand commits, to run dos2unix on the files, and it resulted in a 5-10x slowdown, which was unnacceptable. To counter this, I perform a simple string replacement on non-binary files via python, with nearly zero slowdown.

Second, mercurial stores information historically in the branch name. For some, this information would be bad to lose, so I added a flag to either prepend or append the branch name to the commit message during the conversion.

Let me know what you think of these features.