### PR TITLE
Resolve issues #143 and #160

### DIFF
--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -26,7 +26,12 @@ SFX_MARKS="marks"
 SFX_HEADS="heads"
 SFX_STATE="state"
 GFI_OPTS=""
-PYTHON=${PYTHON:-python2}
+if [ "Msys" = `uname -o` ]; then
+    # Microsoft Windows of Python do not shp a python2.exe
+    PYTHON=${PYTHON:-python}
+else
+    PYTHON=${PYTHON:-python2}
+fi
 
 USAGE="[--quiet] [-r <repo>] [--force] [-m <max>] [-s] [--hgtags] [-A <file>] [-B <file>] [-T <file>] [-M <name>] [-o <name>] [--hg-hash] [-e <encoding>]"
 LONG_USAGE="Import hg repository <repo> up to either tip or <max>


### PR DESCRIPTION
Microsoft Windows distributions of Python do not ship a python2.exe.
Added a simply check for msys. Considered `uname -s` but this includes
both platform bit-ness and Windows OS version so is a moving target.