### PR TITLE
Run 2to3 on project files

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -193,8 +193,8 @@ def export_file_contents(ctx,manifest,files,hgtags,encoding='',plugins={}):
 
     if plugins and plugins['file_data_filters']:
       file_data = {'filename':filename,'file_ctx':file_ctx,'data':d}
-      for filter in plugins['file_data_filters']:
-        filter(file_data)
+      for filter_fn in plugins['file_data_filters']:
+        filter_fn(file_data)
       d=file_data['data']
       filename=file_data['filename']
       file_ctx=file_data['file_ctx']
@@ -253,7 +253,7 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
                   branchesmap,sob,brmap,hgtags,encoding='',fn_encoding='',
                   plugins={}):
   def get_branchname(name):
-    if brmap.has_key(name):
+    if name in brmap:
       return brmap[name]
     n=sanitize_name(name, "branch", branchesmap)
     brmap[name]=n
@@ -268,8 +268,8 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
 
   if plugins and plugins['commit_message_filters']:
     commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc}
-    for filter in plugins['commit_message_filters']:
-      filter(commit_data)
+    for filter_fn in plugins['commit_message_filters']:
+      filter_fn(commit_data)
     branch = commit_data['branch']
     parents = commit_data['parents']
     author = commit_data['author']
@@ -293,7 +293,7 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
 
   if len(parents) == 0:
     # first revision: feed in full manifest
-    added=man.keys()
+    added=list(man.keys())
     added.sort()
     type='full'
   else:
@@ -431,9 +431,9 @@ def branchtip(repo, heads):
 
 def verify_heads(ui,repo,cache,force,branchesmap):
   branches={}
-  for bn, heads in repo.branchmap().iteritems():
+  for bn, heads in repo.branchmap().items():
     branches[bn] = branchtip(repo, heads)
-  l=[(-repo.changelog.rev(n), n, t) for t, n in branches.items()]
+  l=[(-repo.changelog.rev(n), n, t) for t, n in list(branches.items())]
   l.sort()
 
   # get list of hg's branches to verify, don't take all git has

--- a/hg-reset.py
+++ b/hg-reset.py
@@ -24,7 +24,7 @@ def heads(ui,repo,start=None,stop=None,max=None):
   heads = {startrev: 1}
 
   parentrevs = repo.changelog.parentrevs
-  for r in xrange(startrev + 1, max):
+  for r in range(startrev + 1, max):
     for p in parentrevs(r):
       if p in reachable:
         if r not in stoprevs:
@@ -117,19 +117,24 @@ if __name__=='__main__':
   stale,changed,unchanged=get_branches(ui,repo,heads_cache,marks_cache,mapping_cache,options.revision+1)
   good,bad=get_tags(ui,repo,marks_cache,mapping_cache,options.revision+1)
 
-  print "Possibly stale branches:"
-  map(lambda b: sys.stdout.write('\t%s\n' % b),stale.keys())
+  print("Possibly stale branches:")
+  for b in stale.keys():
+    sys.stdout.write('\t%s\n' % b)
 
-  print "Possibly stale tags:"
-  map(lambda b: sys.stdout.write('\t%s on %s (r%s)\n' % (b[0],b[1],b[3])),bad)
+  print("Possibly stale tags:")
+  for b in bad:
+    sys.stdout.write('\t%s on %s (r%s)\n' % (b[0], b[1], b[3]))
 
-  print "Unchanged branches:"
-  map(lambda b: sys.stdout.write('\t%s (r%s)\n' % (b[0],b[2])),unchanged)
+  print("Unchanged branches:")
+  for b in unchanged:
+    sys.stdout.write('\t%s (r%s)\n' % (b[0], b[2]))
 
-  print "Unchanged tags:"
-  map(lambda b: sys.stdout.write('\t%s on %s (r%s)\n' % (b[0],b[1],b[3])),good)
+  print("Unchanged tags:")
+  for b in good:
+    sys.stdout.write('\t%s on %s (r%s)\n' % (b[0], b[1], b[3]))
 
-  print "Reset branches in '%s' to:" % options.headsfile
-  map(lambda b: sys.stdout.write('\t:%s %s\n\t\t(r%s: %s: %s)\n' % (b[0],b[1],b[2],b[4],b[3])),changed)
+  print("Reset branches in '%s' to:" % options.headsfile)
+  for b in changed:
+    sys.stdout.write('\t:%s %s\n\t\t(r%s: %s: %s)\n' % (b[0], b[1], b[2], b[4], b[3]))
 
-  print "Reset ':tip' in '%s' to '%d'" % (options.statusfile,options.revision)
+  print("Reset ':tip' in '%s' to '%d'" % (options.statusfile,options.revision))

--- a/hg2git.py
+++ b/hg2git.py
@@ -111,7 +111,8 @@ def load_cache(filename,get_key=mangle_key):
 
 def save_cache(filename,cache):
   f=open(filename,'w+')
-  map(lambda x: f.write(':%s %s\n' % (str(x),str(cache.get(x)))),cache.keys())
+  for x in cache.keys():
+    f.write(':%s %s\n' % (str(x), str(cache.get(x))))
   f.close()
 
 def get_git_sha1(name,type='heads'):


### PR DESCRIPTION
This does not add Python 3 compatibility because mercurial still does not work with Python 3 (at least according to my tests with mercurial 5.1.1).

However, the changes in this PR do not break Python 2 compatibility and makes the code of fast-export itself compatible with Python 3.