### PR TITLE
Patch for #61

### DIFF
--- a/hg2git.py
+++ b/hg2git.py
@@ -5,7 +5,7 @@
 
 from mercurial import hg,util,ui,templatefilters
 from mercurial import error as hgerror
-from mercurial.scmutil import revsymbol,binnode
+from mercurial.scmutil import revsymbol,binnode,revsingle
 
 import re
 import os
@@ -87,6 +87,9 @@ def get_changeset(ui,repo,revision,authors={},encoding=''):
     desc=desc.decode(encoding).encode('utf8')
   tz="%+03d%02d" % (-timezone / 3600, ((-timezone % 3600) / 60))
   branch=get_branch(extra.get('branch','master'))
+  bookmarks = repo.nodebookmarks(node)
+  if bookmarks: branch="%s_%s"%(branch,bookmarks[0])
+  if 'bookmarks' not in extra: extra['bookmakrs'] = bookmarks
   return (node,manifest,fixup_user(user,authors),(time,tz),files,desc,branch,extra)
 
 def mangle_key(key):


### PR DESCRIPTION
Hello, I ran into the bookmarks / extra heads issue while converting a couple of repos this week, and wrote a small patch to address it -- when building the changeset tuple it checks for bookmarks and, if there are any, appends the first one found to the reported branch name. It does require some cleanup in git before you publish the converted repository, but it worked for us.