### PR TITLE
Ignore obsolete changesets in the source repository. Fixes #173

### DIFF
--- a/hg2git.py
+++ b/hg2git.py
@@ -35,7 +35,9 @@ def setup_repo(url):
   except TypeError:
     myui=ui.ui()
     myui.setconfig('ui', 'interactive', 'off')
-  return myui,hg.repository(myui,url)
+    # Avoids a warning when the repository has obsolete markers
+    myui.setconfig('experimental', 'evolution.createmarkers', True)
+  return myui,hg.repository(myui,url).unfiltered()
 
 def fixup_user(user,authors):
   user=user.strip("\"")


### PR DESCRIPTION
This appears to fix the issue at least for my local repository. It switches to an unfiltered repository (the filtered one throws on an attempt to access obsolete revisions) and then filters out the obsolete revisions when it comes across them.

Also sets a simple configuration to avoid the warning about obsolete revisions being present.