### PR TITLE
Head2branch plugin

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -269,7 +269,7 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
   author = get_author(desc,user,authors)
 
   if plugins and plugins['commit_message_filters']:
-    commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc}
+    commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc, 'revision': revision}
     for filter in plugins['commit_message_filters']:
       filter(commit_data)
     branch = commit_data['branch']

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -453,14 +453,15 @@ def verify_heads(ui,repo,cache,force,branchesmap):
 
   # verify that branch has exactly one head
   t={}
+  unnamed_heads = False
   for h in repo.filtered('visible').heads():
     (_,_,_,_,_,_,branch,_)=get_changeset(ui,repo,h)
     if t.get(branch,False):
-      sys.stderr.write('Error: repository has at least one unnamed head: hg r%s\n' %
+      sys.stderr.write('Error: repository has unnamed head: hg r%s\n' %
           repo.changelog.rev(h))
-      if not force: return False
+      unnamed_heads = True
     t[branch]=True
-
+  if unnamed_heads and not force: return False
   return True
 
 def hg2git(repourl,m,marksfile,mappingfile,headsfile,tipfile,

--- a/plugins/head2branch/README.md
+++ b/plugins/head2branch/README.md
@@ -6,4 +6,4 @@ the first divergent commit for that head.  The revision number for the commit
 should be in decimal form.
 
 To use the plugin, add
-`--plugin create_branch=name,<rev>`.
+`--plugin head2branch=name,<rev>`.

--- a/plugins/head2branch/README.md
+++ b/plugins/head2branch/README.md
@@ -1,0 +1,9 @@
+## Convert Head to Branch
+
+`fast-export` can only handle one head per branch.  This plugin allows one
+to create a new branch from a head by specifying the new branch name and
+the first divergent commit for that head.  The revision number for the commit
+should be in decimal form.
+
+To use the plugin, add
+`--plugin create_branch=name,<rev>`.

--- a/plugins/head2branch/__init__.py
+++ b/plugins/head2branch/__init__.py
@@ -1,0 +1,23 @@
+import sys
+
+def build_filter(args):
+    return Filter(args)
+
+class Filter:
+
+    def __init__(self, args):
+        args = args.split(',')
+        self.branch_name = args[0]
+        self.starting_commit = int(args[1])
+        self.branch_parents = set()
+
+    def commit_message_filter(self, commit_data):
+        rev = commit_data['revision']
+        rev_parents = commit_data['parents']
+        if (rev == self.starting_commit
+            or any(rp in self.branch_parents for rp in rev_parents)
+            ):
+            self.branch_parents.add(rev)
+            commit_data['branch'] = self.branch_name
+            sys.stderr.write('\nchanging r%s to branch %r\n' % (rev, self.branch_name))
+            sys.stderr.flush()


### PR DESCRIPTION
This plugin is able to move commits to a new branch on the fly.  To support this the `commit_data` dict now passes the `revision`, and `verify_heads` now displays all unnamed heads before aborting.