### PR TITLE
Support submodules that are already git repositories.

### DIFF
--- a/README-SUBMODULES.md
+++ b/README-SUBMODULES.md
@@ -2,11 +2,21 @@
 
 ## Introduction
 
-Subrepositories must first be converted in order for the conversion of
-the super repository to know how hg commits map to git commits in the
-sub repositories.  When all subrepositories have been converted, a
-mapping file that maps the mercurial subrepository path to a converted
-git submodule path must be created. The format for this file is:
+hg-fast-export supports migrating mercurial subrepositories in the
+repository being converted into git submodules in the converted repository.
+
+Git submodules must be git repositories while mercurial's subrepositories can
+be git, mercurial or subversion repositories. hg-fast-export will handle any
+git subrepositories automatically, any other kinds must first be converted
+to git repositories. Currently hg-fast-export does not support the conversion
+of subversion subrepositories. The rest of this page covers the conversion of
+mercurial subrepositories which require some manual steps:
+
+The first step for mercurial subrepositories involves converting the
+subrepository into a git repository using hg-fast-export.  When all
+subrepositories have been converted, a mapping file that maps the mercurial
+subrepository path to a converted git submodule path must be created. The
+format for this file is:
 
 "<mercurial subrepo path>"="<git submodule path>"
 "<mercurial subrepo path2>"="<git submodule path2>"

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -171,7 +171,8 @@ def refresh_gitmodules(ctx):
   gitmodules=""
   # Create the .gitmodules file and all submodules
   for name,subrepo_info in ctx.substate.items():
-    gitmodules+=refresh_hg_submodule(name,subrepo_info)
+    if name in submodule_mappings:
+      gitmodules+=refresh_hg_submodule(name,subrepo_info)
 
   if len(gitmodules):
     wr('M 100644 inline .gitmodules')

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -141,33 +141,37 @@ def remove_gitmodules(ctx):
       wr('D %s' % submodule)
   wr('D .gitmodules')
 
+def refresh_hg_submodule(name,subrepo_info):
+  gitRepoLocation=submodule_mappings[name] + "/.git"
+
+  # Populate the cache to map mercurial revision to git revision
+  if not name in subrepo_cache:
+    subrepo_cache[name]=(load_cache(gitRepoLocation+"/hg2git-mapping"),
+                         load_cache(gitRepoLocation+"/hg2git-marks",
+                                    lambda s: int(s)-1))
+
+  (mapping_cache,marks_cache)=subrepo_cache[name]
+  subrepo_hash=subrepo_info[1]
+  if subrepo_hash in mapping_cache:
+    revnum=mapping_cache[subrepo_hash]
+    gitSha=marks_cache[int(revnum)]
+    wr('M 160000 %s %s' % (gitSha,name))
+    sys.stderr.write("Adding/updating submodule %s, revision %s->%s\n"
+                     % (name,subrepo_hash,gitSha))
+    return '[submodule "%s"]\n\tpath = %s\n\turl = %s\n' % (name,name,
+      submodule_mappings[name])
+  else:
+    sys.stderr.write("Warning: Could not find hg revision %s for %s in git %s\n" %
+      (subrepo_hash,name,gitRepoLocation))
+    return ''
+
 def refresh_gitmodules(ctx):
   """Updates list of ctx submodules according to .hgsubstate file"""
   remove_gitmodules(ctx)
   gitmodules=""
   # Create the .gitmodules file and all submodules
   for name,subrepo_info in ctx.substate.items():
-    gitRepoLocation=submodule_mappings[name] + "/.git"
-
-    # Populate the cache to map mercurial revision to git revision
-    if not name in subrepo_cache:
-      subrepo_cache[name]=(load_cache(gitRepoLocation+"/hg2git-mapping"),
-                           load_cache(gitRepoLocation+"/hg2git-marks",
-                                      lambda s: int(s)-1))
-
-    (mapping_cache,marks_cache)=subrepo_cache[name]
-    subrepo_hash=subrepo_info[1]
-    if subrepo_hash in mapping_cache:
-      revnum=mapping_cache[subrepo_hash]
-      gitSha=marks_cache[int(revnum)]
-      wr('M 160000 %s %s' % (gitSha,name))
-      sys.stderr.write("Adding/updating submodule %s, revision %s->%s\n"
-                       % (name,subrepo_hash,gitSha))
-      gitmodules+='[submodule "%s"]\n\tpath = %s\n\turl = %s\n' % (name,name,
-        submodule_mappings[name])
-    else:
-      sys.stderr.write("Warning: Could not find hg revision %s for %s in git %s\n" %
-        (subrepo_hash,name,gitRepoLocation))
+    gitmodules+=refresh_hg_submodule(name,subrepo_info)
 
   if len(gitmodules):
     wr('M 100644 inline .gitmodules')


### PR DESCRIPTION
Although disabled by default hg supports submodules that are either git
or svn repositories. In the git case at least there is no kind of
mapping necessary, we just need to write out the submodule reference
directory.

In this change we always call refresh_gitmodules regardless of whether
there were mappings specified. Git submodules are written out directly
and hg submodules are mapped if a mapping was included.

The changes here look larger than they actually are, none of the logic for finding and applying the mapping for the hg subrepo case is changed, it's just all indented one extra level.