### PR TITLE
Made export_commit more reliable for different python/mercurial versions

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -318,8 +318,8 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
       # later non-merge revision: feed in changed manifest
       # if we have exactly one parent, just take the changes from the
       # manifest without expensively comparing checksums
-      f=repo.status(parents[0],revnode)[:3]
-      added,changed,removed=f[1],f[0],f[2]
+      f=repo.status(parents[0],revnode)
+      added,changed,removed=f.added,f.modified,f.removed
       type='simple delta'
     else: # a merge with two parents
       wr('merge %s' % revnum_to_revref(parents[1], old_marks))


### PR DESCRIPTION
This changed allowed me to run this tool on my linux machine.  It seems like it might be a more reliable way for others to run the tool as well.