### PR TITLE
Allow external URLs to be specified for submodule conversions

### DIFF
--- a/README-SUBMODULES.md
+++ b/README-SUBMODULES.md
@@ -18,9 +18,11 @@ subrepositories have been converted, a mapping file that maps the mercurial
 subrepository path to a converted git submodule path must be created. The
 format for this file is:
 
-"<mercurial subrepo path>"="<git submodule path>"
-"<mercurial subrepo path2>"="<git submodule path2>"
+```
+"<mercurial subrepo path>"="<git submodule path>[|<clone url>]"
+"<mercurial subrepo path2>"="<git submodule path2>[|<clone url2>]"
 ...
+```
 
 The path of this mapping file is then provided with the --subrepo-map
 command line option.
@@ -48,12 +50,25 @@ Create an empty new folder where all the converted git modules will be imported:
     git init
     hg-fast-export.sh -r ~/mercurial/subrepo2
 
+### Determine the remote URLs from which the submodules will be fetched
+
+These are the URLs that will be written to the .gitmodules file. Adding them to
+the mapping file will allow other users to update their submodules without first
+having to clone them to specific locations on their own machines.
+
+For this example we'll assume that the subrepos are going to be hosted on github:
+
+    submodule1 -> https://github.com/myname/submodule1.git
+    submodule2 -> https://github.com/myname/submodule2.git
+
 ### Create mapping file
     cd ~/imported-gits
     cat > submodule-mappings << EOF
-    "subrepo/subrepo1"="../submodule1"
-    "subrepo/subrepo2"="../submodule2"
+    "subrepo/subrepo1"="../submodule1|https://github.com/myname/submodule1.git"
+    "subrepo/subrepo2"="../submodule2|https://github.com/myname/submodule2.git"
     EOF
+
+Note that if the external URL is omitted, the local paths will be used instead.
 
 ### Convert main repository
     cd ~/imported-gits
@@ -69,7 +84,7 @@ like:
 
     [submodule "subrepo/subrepo1"]
           path = subrepo/subrepo1
-          url = ../submodule1
+          url = https://github.com/myname/submodule1.git
     [submodule "subrepo/subrepo2"]
           path = subrepo/subrepo2
-          url = ../submodule2
+          url = https://github.com/myname/submodule2.git


### PR DESCRIPTION
This change allows remote URLs (e.g. Github URLs) to be written to the .gitmodules file instead of just local paths. This is important for allowing users to clone a converted repository with submodules without having to first clone all of the submodules to their machine first.