### PR TITLE
Add a plugin to prefix an issue number with a user-defined string

### DIFF
--- a/plugins/issue_prefix/README.md
+++ b/plugins/issue_prefix/README.md
@@ -1,0 +1,19 @@
+## Issue Prefix
+
+When migrating to other source code hosting sites, there are cases where a
+project maintainer might want to reset their issue tracker and not have old
+issue numbers in commit messages referring to the wrong issue.  One way around
+this is to prefix issue numbers with some other string.
+
+If migrating to GitHub, this issue prefixing can be paired with GitHub's
+autolinking capabilitiy to link back to a different issue tracker:
+https://help.github.com/en/github/administering-a-repository/configuring-autolinks-to-reference-external-resources
+
+To use this plugin, add:
+`--plugin=issue_prefix=<some_prefix>`
+
+Example:
+`--plugin=issue_prefix=BB-`
+
+This will prefix issue numbers with the string `BB-`.  Example: `#123` will
+change to `#BB-123`.

--- a/plugins/issue_prefix/__init__.py
+++ b/plugins/issue_prefix/__init__.py
@@ -1,0 +1,15 @@
+# encoding=UTF-8
+"""__init__.py"""
+import re
+
+def build_filter(args):
+    return Filter(args)
+
+class Filter:
+    def __init__(self, args):
+        self.prefix = args
+
+    def commit_message_filter(self, commit_data):
+        for match in re.findall('#[1-9][0-9]+', commit_data['desc']):
+            commit_data['desc'] = commit_data['desc'].replace(
+                match, '#%s%s' % (self.prefix, match[1:]))


### PR DESCRIPTION
This PR adds a python plugin for prefixing an issue number with a user-defined string.

The use case for this is that, when migrating one of my projects from bitbucket to github, I wish to prefix all of my bitbucket issue numbers with something (e.g. `'BITBUCKET-'`) so that the issue numbers don't ever collide with my new issues in the github issue tracker.