### PR TITLE
Adding a new plugin to overwrite null messages.

### DIFF
--- a/plugins/overwrite_null_messages/README.md
+++ b/plugins/overwrite_null_messages/README.md
@@ -1,0 +1,23 @@
+## Overwrite Null Commit Messages
+
+There are cases (such as when creating a new, empty snippet on bitbucket
+before they deprecated mercurial repositories) where you could create a
+new repo with a single commit in it, but the message would be null.  Then,
+when attempting to convert this repository to a git repo and pushing to 
+a new host, the git push would fail with an error like this:
+
+    error: a NUL byte in commit log message not allowed
+
+To get around this, you may provide a string that will be used in place of
+a null byte in commit messages.
+
+To use the plugin, add
+
+    --plugin overwrite_null_messages=""
+
+This will use the default commit message `"<empty commit message>"`.
+
+Or to specify a different commit message, you may pass this in at the
+command line like so:
+
+    --plugin overwrite_null_messages="use this message instead"

--- a/plugins/overwrite_null_messages/__init__.py
+++ b/plugins/overwrite_null_messages/__init__.py
@@ -1,0 +1,16 @@
+def build_filter(args):
+    return Filter(args)
+
+class Filter:
+    def __init__(self, args):
+        if args == '':
+            message = '<empty commit message>'
+        else:
+            message = args
+        self.message = message
+
+    def commit_message_filter(self,commit_data):
+        # Only write the commit message if the recorded commit
+        # message is null.
+        if commit_data['desc'] == '\x00':
+            commit_data['desc'] = self.message


### PR DESCRIPTION
This PR adds a plugin to overwrite null commit messages (which git doesn't handle very well) with a user-defined string.  A reasonable default is assumed.

The use case for this is that bitbucket allows you to create a mercurial snippet with an empty commit message.  When the repository is converted with `hg-fast-export`, I'm then unable to push the repository to github because of this null message.