### PR TITLE
fix 5.3 compatibility

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -320,8 +320,8 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
       # later non-merge revision: feed in changed manifest
       # if we have exactly one parent, just take the changes from the
       # manifest without expensively comparing checksums
-      f=repo.status(parents[0],revnode)[:3]
-      added,changed,removed=f[1],f[0],f[2]
+      f=repo.status(parents[0],revnode)
+      added,changed,removed=f.added,f.modified,f.removed
       type='simple delta'
     else: # a merge with two parents
       wr('merge %s' % revnum_to_revref(parents[1], old_marks))


### PR DESCRIPTION
fixes #196

Status has always been a tuple, but since 5.3, commit: https://www.mercurial-scm.org/repo/hg/rev/c5548b0b6847. is it an object. Therefore the `__getitem__` of the tuple isn't available anymore.

This fix is compatible with mercurial>=4.6, as the old status tuple still has the same properties.