### PR TITLE
Fix issue #166: Ignore files and directories called .git

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ hg-fast-export supports multiple branches but only named branches with
 exactly one head each. Otherwise commits to the tip of these heads
 within the branch will get flattened into merge commits.
 
+hg-fast-export will ignore any files or directories tracked by mercurial
+called `.git`, and will print a warning if it encounters one. Git cannot
+track such files or directories. This is not to be confused with submodules,
+which are described in README-SUBMODULES.md.
+
 As each git-fast-import run creates a new pack file, it may be
 required to repack the repository quite often for incremental imports
 (especially when importing a small number of changesets per

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -204,6 +204,9 @@ def export_file_contents(ctx,manifest,files,hgtags,encoding='',plugins={}):
       filename=file.decode(encoding).encode('utf8')
     else:
       filename=file
+    if '.git' in filename.split(os.path.sep):
+      sys.stderr.write('Ignoring file %s which cannot be tracked by git\n' % filename)
+      continue
     file_ctx=ctx.filectx(file)
     d=file_ctx.data()
 


### PR DESCRIPTION
Ignore files and directories called `.git`
Git cannot track these files. Print a warning if encountering one.

Fixes #166