### PR TITLE
Add additional options to branch_name_in_commit plugin

### DIFF
--- a/plugins/branch_name_in_commit/README.md
+++ b/plugins/branch_name_in_commit/README.md
@@ -6,5 +6,15 @@ during the migration to Git. You can use this plugin to either
 prepend or append the branch name from the mercurial
 commit into the commit message in Git.
 
+Valid arguments are:
+
+- `start`: write the branch name at the start of the commit
+- `end`: write the branch name at the end of the commit
+- `sameline`: if `start` specified, put a colon and a space
+  after the branch name, such that the commit message reads
+  `branch_name: first line of commit message`. Otherwise, the
+  branch name is on the first line of the commit message by itself.
+- `skipmaster`: Don't write the branch name if the branch is `master`.
+
 To use the plugin, add
-`--plugin branch_name_in_commit=(start|end)`.
+`--plugin branch_name_in_commit=<comma_separated_list_of_args>`.


### PR DESCRIPTION
- Allow skipping writing the branch name if the branch is 'master'.

- Allow writing the branch name on the same line as the first line of
  the commit message separated by a colon, instead of it having its own
  line.

This is backward compatible, the previous argument format is still valid.