### PR TITLE
Support Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ first time.
 System Requirements
 -------------------
 
-This project depends on Python 2.7 and the Mercurial >= 4.6
-package. If Python is not installed, install it before proceeding. The
-Mercurial package can be installed with `pip install mercurial`.
+This project depends on Python 2.7 or 3.5+, and the Mercurial >= 4.6
+package (>= 5.2, if Python 3.5+). If Python is not installed, install
+it before proceeding. TheMercurial package can be installed with
+`pip install mercurial`.
 
 On windows the bash that comes with "Git for Windows" is known to work
 well.

--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -28,25 +28,20 @@ SFX_STATE="state"
 GFI_OPTS=""
 
 if [ -z "${PYTHON}" ]; then
-    # $PYTHON is not set, so we try to find a working python 2.7 to
-    # use. PEP 394 tells us to use 'python2', otherwise try plain
-    # 'python'.
-    if command -v python2 > /dev/null; then
-	PYTHON="python2"
-    elif command -v python > /dev/null; then
-	PYTHON="python"
-    else
-        echo "Could not find any python interpreter, please use the 'PYTHON'" \
-	     "environment variable to specify the interpreter to use."
-        exit 1
-    fi
+    # $PYTHON is not set, so we try to find a working python with mercurial:
+    for python_cmd in python2 python python3; do
+        if command -v $python_cmd > /dev/null; then
+            $python_cmd -c 'import mercurial' 2> /dev/null
+            if [ $? -eq 0 ]; then
+                PYTHON=$python_cmd
+                break
+            fi
+        fi
+    done
 fi
-
-# Check that the python specified by the user or autodetected above is
-# >= 2.7 and < 3.
-if ! ${PYTHON} -c 'import sys; v=sys.version_info; exit(0 if v.major == 2 and v.minor >= 7 else 1)' > /dev/null 2>&1 ; then
-    echo "${PYTHON} is not a working python 2.7 interpreter, please use the" \
-	 "'PYTHON' environment variable to specify the interpreter to use."
+if [ -z "${PYTHON}" ]; then
+    echo "Could not find a python interpreter with the mercurial module available. " \
+        "Please use the 'PYTHON' environment variable to specify the interpreter to use."
     exit 1
 fi
 

--- a/hg-reset.sh
+++ b/hg-reset.sh
@@ -11,7 +11,24 @@ SFX_MAPPING="mapping"
 SFX_HEADS="heads"
 SFX_STATE="state"
 QUIET=""
-PYTHON=${PYTHON:-python}
+
+if [ -z "${PYTHON}" ]; then
+    # $PYTHON is not set, so we try to find a working python with mercurial:
+    for python_cmd in python2 python python3; do
+        if command -v $python_cmd > /dev/null; then
+            $python_cmd -c 'import mercurial' 2> /dev/null
+            if [ $? -eq 0 ]; then
+                PYTHON=$python_cmd
+                break
+            fi
+        fi
+    done
+fi
+if [ -z "${PYTHON}" ]; then
+    echo "Could not find a python interpreter with the mercurial module available. " \
+        "Please use the 'PYTHON'environment variable to specify the interpreter to use."
+    exit 1
+fi
 
 USAGE="[-r <repo>] -R <rev>"
 LONG_USAGE="Print SHA1s of latest changes per branch up to <rev> useful

--- a/hg2git.py
+++ b/hg2git.py
@@ -12,14 +12,21 @@ import os
 import sys
 import subprocess
 
+PY2 = sys.version_info.major < 3
+if PY2:
+  str = unicode
+  fsencode = lambda s: s.encode(sys.getfilesystemencoding())
+else:
+  from os import fsencode
+
 # default git branch name
-cfg_master='master'
+cfg_master=b'master'
 # default origin name
-origin_name=''
+origin_name=b''
 # silly regex to see if user field has email address
-user_re=re.compile('([^<]+) (<[^>]*>)$')
+user_re=re.compile(b'([^<]+) (<[^>]*>)$')
 # silly regex to clean out user names
-user_clean_re=re.compile('^["]([^"]+)["]$')
+user_clean_re=re.compile(b'^["]([^"]+)["]$')
 
 def set_default_branch(name):
   global cfg_master
@@ -34,26 +41,26 @@ def setup_repo(url):
     myui=ui.ui(interactive=False)
   except TypeError:
     myui=ui.ui()
-    myui.setconfig('ui', 'interactive', 'off')
+    myui.setconfig(b'ui', b'interactive', b'off')
     # Avoids a warning when the repository has obsolete markers
-    myui.setconfig('experimental', 'evolution.createmarkers', True)
-  return myui,hg.repository(myui,url).unfiltered()
+    myui.setconfig(b'experimental', b'evolution.createmarkers', True)
+  return myui,hg.repository(myui, fsencode(url)).unfiltered()
 
 def fixup_user(user,authors):
-  user=user.strip("\"")
+  user=user.strip(b"\"")
   if authors!=None:
     # if we have an authors table, try to get mapping
     # by defaulting to the current value of 'user'
     user=authors.get(user,user)
-  name,mail,m='','',user_re.match(user)
+  name,mail,m=b'',b'',user_re.match(user)
   if m==None:
     # if we don't have 'Name <mail>' syntax, extract name
     # and mail from hg helpers. this seems to work pretty well.
     # if email doesn't contain @, replace it with devnull@localhost
     name=templatefilters.person(user)
-    mail='<%s>' % templatefilters.email(user)
-    if '@' not in mail:
-      mail = '<devnull@localhost>'
+    mail=b'<%s>' % templatefilters.email(user)
+    if b'@' not in mail:
+      mail = b'<devnull@localhost>'
   else:
     # if we have 'Name <mail>' syntax, everything is fine :)
     name,mail=m.group(1),m.group(2)
@@ -62,15 +69,15 @@ def fixup_user(user,authors):
   m2=user_clean_re.match(name)
   if m2!=None:
     name=m2.group(1)
-  return '%s %s' % (name,mail)
+  return b'%s %s' % (name,mail)
 
 def get_branch(name):
   # 'HEAD' is the result of a bug in mutt's cvs->hg conversion,
   # other CVS imports may need it, too
-  if name=='HEAD' or name=='default' or name=='':
+  if name==b'HEAD' or name==b'default' or name==b'':
     name=cfg_master
   if origin_name:
-    return origin_name + '/' + name
+    return origin_name + b'/' + name
   return name
 
 def get_changeset(ui,repo,revision,authors={},encoding=''):
@@ -79,16 +86,16 @@ def get_changeset(ui,repo,revision,authors={},encoding=''):
   # how it fails
   try:
     node=repo.lookup(revision)
-  except hgerror.ProgrammingError:
-    node=binnode(revsymbol(repo,str(revision))) # We were given a numeric rev
+  except (TypeError, hgerror.ProgrammingError):
+    node=binnode(revsymbol(repo, b"%d" % revision)) # We were given a numeric rev
   except hgerror.RepoLookupError:
     node=revision # We got a raw hash
   (manifest,user,(time,timezone),files,desc,extra)=repo.changelog.read(node)
   if encoding:
     user=user.decode(encoding).encode('utf8')
     desc=desc.decode(encoding).encode('utf8')
-  tz="%+03d%02d" % (-timezone / 3600, ((-timezone % 3600) / 60))
-  branch=get_branch(extra.get('branch','master'))
+  tz=b"%+03d%02d" % (-timezone // 3600, ((-timezone % 3600) // 60))
+  branch=get_branch(extra.get(b'branch', b'master'))
   return (node,manifest,fixup_user(user,authors),(time,tz),files,desc,branch,extra)
 
 def mangle_key(key):
@@ -98,28 +105,33 @@ def load_cache(filename,get_key=mangle_key):
   cache={}
   if not os.path.exists(filename):
     return cache
-  f=open(filename,'r')
+  f=open(filename,'rb')
   l=0
   for line in f.readlines():
     l+=1
-    fields=line.split(' ')
-    if fields==None or not len(fields)==2 or fields[0][0]!=':':
+    fields=line.split(b' ')
+    if fields==None or not len(fields)==2 or fields[0][0:1]!=b':':
       sys.stderr.write('Invalid file format in [%s], line %d\n' % (filename,l))
       continue
     # put key:value in cache, key without ^:
-    cache[get_key(fields[0][1:])]=fields[1].split('\n')[0]
+    cache[get_key(fields[0][1:])]=fields[1].split(b'\n')[0]
   f.close()
   return cache
 
 def save_cache(filename,cache):
-  f=open(filename,'w+')
-  map(lambda x: f.write(':%s %s\n' % (str(x),str(cache.get(x)))),cache.keys())
+  f=open(filename,'wb')
+  for key, value in cache.items():
+    if not isinstance(key, bytes):
+      key = str(key).encode('utf8')
+    if not isinstance(value, bytes):
+      value = str(value).encode('utf8')
+    f.write(b':%s %s\n' % (key, value))
   f.close()
 
 def get_git_sha1(name,type='heads'):
   try:
     # use git-rev-parse to support packed refs
-    ref="refs/%s/%s" % (type,name)
+    ref="refs/%s/%s" % (type,name.decode('utf8'))
     l=subprocess.check_output(["git", "rev-parse", "--verify", "--quiet", ref])
     if l == None or len(l) == 0:
       return None

--- a/plugins/branch_name_in_commit/__init__.py
+++ b/plugins/branch_name_in_commit/__init__.py
@@ -15,9 +15,11 @@ class Filter:
             raise ValueError("Unknown args: " + ','.join(args))
 
     def commit_message_filter(self, commit_data):
-        if not (self.skip_master and commit_data['branch'] == 'master'):
+        if not (self.skip_master and commit_data['branch'] == b'master'):
             if self.start:
-                sep = ': ' if self.sameline else '\n' 
+                sep = b': ' if self.sameline else b'\n'
                 commit_data['desc'] = commit_data['branch'] + sep + commit_data['desc']
             if self.end:
-                commit_data['desc'] = commit_data['desc'] + '\n' + commit_data['branch']
+                commit_data['desc'] = (
+                    commit_data['desc'] + b'\n' + commit_data['branch']
+                )

--- a/plugins/dos2unix/__init__.py
+++ b/plugins/dos2unix/__init__.py
@@ -8,4 +8,4 @@ class Filter():
     def file_data_filter(self,file_data):
         file_ctx = file_data['file_ctx']
         if not file_ctx.isbinary():
-            file_data['data'] = file_data['data'].replace('\r\n', '\n')
+            file_data['data'] = file_data['data'].replace(b'\r\n', b'\n')

--- a/plugins/issue_prefix/__init__.py
+++ b/plugins/issue_prefix/__init__.py
@@ -7,9 +7,11 @@ def build_filter(args):
 
 class Filter:
     def __init__(self, args):
+        if not isinstance(args, bytes):
+            args = args.encode('utf8') 
         self.prefix = args
 
     def commit_message_filter(self, commit_data):
-        for match in re.findall('#[1-9][0-9]+', commit_data['desc']):
+        for match in re.findall(b'#[1-9][0-9]+', commit_data['desc']):
             commit_data['desc'] = commit_data['desc'].replace(
-                match, '#%s%s' % (self.prefix, match[1:]))
+                match, b'#%s%s' % (self.prefix, match[1:]))

--- a/plugins/overwrite_null_messages/__init__.py
+++ b/plugins/overwrite_null_messages/__init__.py
@@ -4,13 +4,13 @@ def build_filter(args):
 class Filter:
     def __init__(self, args):
         if args == '':
-            message = '<empty commit message>'
+            message = b'<empty commit message>'
         else:
-            message = args
+            message = args.encode('utf8')
         self.message = message
 
     def commit_message_filter(self,commit_data):
         # Only write the commit message if the recorded commit
         # message is null.
-        if commit_data['desc'] == '\x00':
+        if commit_data['desc'] == b'\x00':
             commit_data['desc'] = self.message


### PR DESCRIPTION
Port hg-fast-import to Python 2/3 polyglot code.

Since mercurial accepts and returns bytestrings for all repository data,
the approach I've taken here is to use bytestrings throughout the
hg-fast-import code. All strings pertaining to repository data are
bytestrings. This means the code is using the same string datatype for
this data on Python 3 as it did (and still does) on Python 2.

Repository data coming from subprocess calls to git, or read from files,
is also left as the bytestrings either returned from
subprocess.check_output or as read from the file in 'rb' mode.

Regexes and string literals that are used with repository data have
all had a b'' prefix added.

When repository data is used in error/warning messages, it is decoded
with the UTF8 codec for printing.

With this patch, hg-fast-export.py writes binary output to
sys.stdout.buffer on Python 3 - on Python 2 this doesn't exist and it
still uses sys.stdout.

The only strings that are left as "native" strings and not coerced to
bytestrings are filepaths passed in on the command line, and dictionary
keys for internal data structures used by hg-fast-import.py, that do
not originate in repository data.

Mapping files are read in 'rb' mode, and thus bytestrings are read from
them. When an encoding is given, their contents are decoded with that
encoding, but then immediately encoded again with UTF8 and they are
returned as the resulting bytestrings

Other necessary changes were:

 - indexing byestrings with a single index returns an integer on Python 3.
   These indexing operations have been replaced with a one-element
   slice: x[0] -> x[0:1] or x[-1] -> [-1:] so as to return a bytestring.

 - raw_hash.encode('hex_codec') replaced with binascii.hexlify(raw_hash)

 - str(integer) -> b'%d' % integer

 - 'string_escape' codec replaced with 'unicode_escape' (which was
    backported to python 2.7). Strings decoded with this codec were then
    immediately re-encoded with UTF8.

 - Calls to map() intended to execute their contents immediately were
   unwrapped or converted to list comprehensions, since map() is an
   iterator and does not execute until iterated over.

hg-fast-export.sh has been modified to not require Python 2. Instead, if
PYTHON has not been defined, it checks python2, python, then python3,
and uses the first one that exists and can import the mercurial module.

I've tested that this patch produces identical output from hg-fast-export.py when run with Python 2 or 3 on an example repo with a few branches, mercurial subrepos, an author mapping file, and every plugin used.

Running the test with coverage.py gives the following coverage:
```
file                                            hit     missed  skipped  %
---------------------------------------------------------------------------
hg-fast-export.py                               467     91      0       81%
hg2git.py                                       100     14      0       86%
pluginloader/__init__.py                        17      3       0       82%
plugins/branch_name_in_commit/__init__.py       20      3       0       85%
plugins/dos2unix/__init__.py                    9       0       0       100%
plugins/issue_prefix/__init__.py                10      0       0       100%
plugins/shell_filter_file_contents/__init__.py  24      4       0       83%
```

I don't really know what hg-reset.py is for, I've ported it too, and whilst it's pretty simple code, that is untested. 