### PR TITLE
hg-fast-export.sh: import revsymbol in python test

### DIFF
--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -31,7 +31,7 @@ if [ -z "${PYTHON}" ]; then
     # $PYTHON is not set, so we try to find a working python with mercurial:
     for python_cmd in python2 python python3; do
         if command -v $python_cmd > /dev/null; then
-            $python_cmd -c 'import mercurial' 2> /dev/null
+            $python_cmd -c 'from mercurial.scmutil import revsymbol' 2> /dev/null
             if [ $? -eq 0 ]; then
                 PYTHON=$python_cmd
                 break
@@ -40,7 +40,7 @@ if [ -z "${PYTHON}" ]; then
     done
 fi
 if [ -z "${PYTHON}" ]; then
-    echo "Could not find a python interpreter with the mercurial module available. " \
+    echo "Could not find a python interpreter with the mercurial module >= 4.6 available. " \
         "Please use the 'PYTHON' environment variable to specify the interpreter to use."
     exit 1
 fi


### PR DESCRIPTION
I have an Ubuntu bionic system with a system install of mercurial 4.5.3 using python2 and a python3 venv with mercurial 5.3, but when I try to run `hg-fast-export.sh` from within my python3 venv, it chooses `python2` because it is first in the list, and `import mercurial` succeeds for it, but it quickly fails with "cannot import name revsymbol" (like #149). This changes the test command to match the failing import, and now it correctly chooses the correct python executable for me.