### PR TITLE
Fix failure to print error message in verify_heads

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -483,7 +483,7 @@ def verify_heads(ui,repo,cache,force,branchesmap):
     if sha1!=c:
       stderr_buffer.write(
         b'Error: Branch [%s] modified outside hg-fast-export:'
-        b'\n%s (repo) != %s (cache)\n' % (b, sha1, c)
+        b'\n%s (repo) != %s (cache)\n' % (b, b'<None>' if sha1 is None else sha1, c)
       )
       if not force: return False
 


### PR DESCRIPTION
On Python 3, `b'%s' % None` fails with a TypeError. In verify_heads,
an error message prints the sha1 of a git commit, but that sha1
can be None.

This commit instead prints `b'<None>'` if sha1 is None.