### PR TITLE
Fix bug in ignoring .git files/folders on Windows

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -216,7 +216,7 @@ def export_file_contents(ctx,manifest,files,hgtags,encoding='',plugins={}):
       filename=file.decode(encoding).encode('utf8')
     else:
       filename=file
-    if b'.git' in filename.split(os.path.sep.encode()):
+    if b'.git' in filename.split(b'/'): # Even on Windows, the path separator is / here.
       stderr_buffer.write(
         b'Ignoring file %s which cannot be tracked by git\n' % filename
       )


### PR DESCRIPTION
Mercurial internally stores (most) filepaths using forward slashes, and
returns them as such from its Python API, even on Windows.

So the splitting up of filepaths with `os.path.sep` was incorrect,
resulting in `.git` files (those within a subdirectory, anyway)
not being ignored on Windows as intended. Splitting on `b'\'` regardless
of OS fixes this.