### PR TITLE
Fix TypeError when using -M command line argument (issue #213)

### DIFF
--- a/hg2git.py
+++ b/hg2git.py
@@ -30,7 +30,7 @@ user_clean_re=re.compile(b'^["]([^"]+)["]$')
 
 def set_default_branch(name):
   global cfg_master
-  cfg_master = name
+  cfg_master = name.encode('utf8') if not isinstance(name, bytes) else name
 
 def set_origin_name(name):
   global origin_name


### PR DESCRIPTION
hg-fast-export.sanitize_name expects branch name to be a bytes
object. Command line parser gives out str objects. Convert
possible str object to bytes in hg2git.set_default_branch().

I didn't dig this issue any further. I just needed to get my hg repos converted to git and this fix got me further.

FIxes #213 