### PR TITLE
Fix backward incompatible change for hg < 5.1

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -477,7 +477,7 @@ def branchtip(repo, heads):
 
 def verify_heads(ui,repo,cache,force,branchesmap):
   branches={}
-  for bn, heads in repo.branchmap().items():
+  for bn, heads in repo.branchmap().iteritems():
     branches[bn] = branchtip(repo, heads)
   l=[(-repo.changelog.rev(n), n, t) for t, n in branches.items()]
   l.sort()


### PR DESCRIPTION
The port to Python 3 in b961f146 changed `repo.branchmap().iteritems()`
to use `.items()` instead. However, the object returned by mercurial
isn't a dictionary and its `.items()` method was only introduced (as an
alias for `iteritems`) in hg 5.1. `iteritems()` still exists, so let's
keep using it for now to retain compatibility with hg < 5.1.

Fixes #225