### PR TITLE
Add remote of the git repostiory for sub-module

### DIFF
--- a/README-SUBMODULES.md
+++ b/README-SUBMODULES.md
@@ -73,3 +73,16 @@ like:
     [submodule "subrepo/subrepo2"]
           path = subrepo/subrepo2
           url = ../submodule2
+
+An additional enhancement has been added to hg-fast-export that will recognize repositories
+which are connected to a remote repository.
+
+This allows the .gitmodules file to have references to the remote rather than your local
+copy of the submodule. The .gitmodules file in this case would look like the following:
+
+    [submodule "subrepo/subrepo1"]
+          path = subrepo/subrepo1
+          url = git@github.com:user/submodule1.git
+    [submodule "subrepo/subrepo2"]
+          path = subrepo/subrepo2
+          url = git@github.com:user/submodule2.git

--- a/README-SUBMODULES.md
+++ b/README-SUBMODULES.md
@@ -74,11 +74,13 @@ like:
           path = subrepo/subrepo2
           url = ../submodule2
 
-An additional enhancement has been added to hg-fast-export that will recognize repositories
-which are connected to a remote repository.
+For submodules which will be stored on remote repositories, the conversion has been
+enhanced to point at the remote. If converting submodulse from mercurial, these must
+have remote origin set.
 
-This allows the .gitmodules file to have references to the remote rather than your local
-copy of the submodule. The .gitmodules file in this case would look like the following:
+During conversion the submodule remote is recognized, allowing the .gitmodules file to have 
+references to the remote rather than your local copy of the submodule. The .gitmodules file 
+in this case would look like the following:
 
     [submodule "subrepo/subrepo1"]
           path = subrepo/subrepo1


### PR DESCRIPTION
The current sub-module support will only add the local mapping to the submodule. This code change will check the submodule for a remote entry. If it exists, it will add that remote, rather than the local mapping to the .gitmodules file