### PR TITLE
Head2branch plugin (remastered)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ defined filter methods in the [dos2unix](./plugins/dos2unix) and
 [branch_name_in_commit](./plugins/branch_name_in_commit) plugins.
 
 ```
-commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc}
+commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc, 'revision': revision}
 
 def commit_message_filter(self,commit_data):
 ```

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ defined filter methods in the [dos2unix](./plugins/dos2unix) and
 [branch_name_in_commit](./plugins/branch_name_in_commit) plugins.
 
 ```
-commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc, 'revision': revision}
+commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc, 'revision': revision, 'hg_hash': hg_hash}
 
 def commit_message_filter(self,commit_data):
 ```

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ exactly one head each. Otherwise commits to the tip of these heads
 within the branch will get flattened into merge commits. Chris J
 Billington's [hg-export-tool] can help you to handle branches with
 duplicate heads.
+Alternatively, you can use the [head2branch plugin](./plugins/head2branch)
+to create a new named branch from an unnamed head.
 
 hg-fast-export will ignore any files or directories tracked by mercurial
 called `.git`, and will print a warning if it encounters one. Git cannot

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -497,16 +497,17 @@ def verify_heads(ui,repo,cache,force,branchesmap):
 
   # verify that branch has exactly one head
   t={}
+  unnamed_heads=False
   for h in repo.filtered(b'visible').heads():
     (_,_,_,_,_,_,branch,_)=get_changeset(ui,repo,h)
     if t.get(branch,False):
       stderr_buffer.write(
-        b'Error: repository has at least one unnamed head: hg r%d\n'
+        b'Error: repository has an unnamed head: hg r%d\n'
         % repo.changelog.rev(h)
       )
-      if not force: return False
+      unnamed_heads=True
     t[branch]=True
-
+  if unnamed_heads and not force: return False
   return True
 
 def hg2git(repourl,m,marksfile,mappingfile,headsfile,tipfile,

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -302,9 +302,10 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
 
   parents = [p for p in repo.changelog.parentrevs(revision) if p >= 0]
   author = get_author(desc,user,authors)
+  hg_hash=revsymbol(repo,b"%d" % revision).hex()
 
   if plugins and plugins['commit_message_filters']:
-    commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc, 'revision': revision}
+    commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc, 'revision': revision, 'hg_hash': hg_hash}
     for filter in plugins['commit_message_filters']:
       filter(commit_data)
     branch = commit_data['branch']

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -304,7 +304,7 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
   author = get_author(desc,user,authors)
 
   if plugins and plugins['commit_message_filters']:
-    commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc}
+    commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc, 'revision': revision}
     for filter in plugins['commit_message_filters']:
       filter(commit_data)
     branch = commit_data['branch']

--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -45,7 +45,7 @@ if [ -z "${PYTHON}" ]; then
     exit 1
 fi
 
-USAGE="[--quiet] [-r <repo>] [--force] [-m <max>] [-s] [--hgtags] [-A <file>] [-B <file>] [-T <file>] [-M <name>] [-o <name>] [--hg-hash] [-e <encoding>]"
+USAGE="[--quiet] [-r <repo>] [--force] [--ignore-unnamed-heads] [-m <max>] [-s] [--hgtags] [-A <file>] [-B <file>] [-T <file>] [-M <name>] [-o <name>] [--hg-hash] [-e <encoding>]"
 LONG_USAGE="Import hg repository <repo> up to either tip or <max>
 If <repo> is omitted, use last hg repository as obtained from state file,
 GIT_DIR/$PFX-$SFX_STATE by default.

--- a/plugins/head2branch/README.md
+++ b/plugins/head2branch/README.md
@@ -2,11 +2,12 @@
 
 `fast-export` can only handle one head per branch. This plugin makes it possible
 to create a new branch from a head by specifying the new branch name and
-the first divergent commit for that head.  The revision number for the commit
-should be in decimal form.
+the first divergent commit for that head.
+
+Note: the hg hash must be in the full form, 40 hexadecimal characters.
 
 Note: you must run `fast-export` with `--ignore-unnamed-heads` option,
 otherwise, the conversion will fail.
 
-To use the plugin, add the command line flag `--plugin head2branch=name,<rev>`.
+To use the plugin, add the command line flag `--plugin head2branch=name,<hg_hash>`.
 The flag can be given multiple times to name more than one head.

--- a/plugins/head2branch/README.md
+++ b/plugins/head2branch/README.md
@@ -1,0 +1,12 @@
+## Convert Head to Branch
+
+`fast-export` can only handle one head per branch. This plugin makes it possible
+to create a new branch from a head by specifying the new branch name and
+the first divergent commit for that head.  The revision number for the commit
+should be in decimal form.
+
+Note: you must run `fast-export` with `--ignore-unnamed-heads` option,
+otherwise, the conversion will fail.
+
+To use the plugin, add the command line flag `--plugin head2branch=name,<rev>`.
+The flag can be given multiple times to name more than one head.

--- a/plugins/head2branch/__init__.py
+++ b/plugins/head2branch/__init__.py
@@ -7,17 +7,18 @@ class Filter:
 
     def __init__(self, args):
         args = args.split(',')
-        self.branch_name = args[0]
-        self.starting_commit = int(args[1])
+        self.branch_name = args[0].encode('ascii', 'replace')
+        self.starting_commit_hash = args[1].encode('ascii', 'strict')
         self.branch_parents = set()
 
     def commit_message_filter(self, commit_data):
+        hg_hash = commit_data['hg_hash']
         rev = commit_data['revision']
         rev_parents = commit_data['parents']
-        if (rev == self.starting_commit
+        if (hg_hash == self.starting_commit_hash
             or any(rp in self.branch_parents for rp in rev_parents)
             ):
             self.branch_parents.add(rev)
-            commit_data['branch'] = self.branch_name.encode('ascii', 'replace')
+            commit_data['branch'] = self.branch_name
             sys.stderr.write('\nchanging r%s to branch %r\n' % (rev, self.branch_name))
             sys.stderr.flush()

--- a/plugins/head2branch/__init__.py
+++ b/plugins/head2branch/__init__.py
@@ -1,0 +1,23 @@
+import sys
+
+def build_filter(args):
+    return Filter(args)
+
+class Filter:
+
+    def __init__(self, args):
+        args = args.split(',')
+        self.branch_name = args[0]
+        self.starting_commit = int(args[1])
+        self.branch_parents = set()
+
+    def commit_message_filter(self, commit_data):
+        rev = commit_data['revision']
+        rev_parents = commit_data['parents']
+        if (rev == self.starting_commit
+            or any(rp in self.branch_parents for rp in rev_parents)
+            ):
+            self.branch_parents.add(rev)
+            commit_data['branch'] = self.branch_name.encode('ascii', 'replace')
+            sys.stderr.write('\nchanging r%s to branch %r\n' % (rev, self.branch_name))
+            sys.stderr.flush()


### PR DESCRIPTION
This plugin is able to move commits to a new branch on the fly. To support this the `commit_data` dict now passes the `hg_hash`, and `verify_heads` now displays all unnamed heads before aborting if the `--ignore-unnamed-heads` flag is passed.

@ethanfurman is the original author of this PR (see #178)