### PR TITLE
Add fix_path plugin

### DIFF
--- a/plugins/fix_path/README.md
+++ b/plugins/fix_path/README.md
@@ -1,0 +1,12 @@
+## Fix pathnames
+
+Pathnames in hg repositories can be of the form /folder//subfolder/...
+this results in a crash with the following message:
+```
+fatal: Empty path component found in input
+```
+See [github issue](https://github.com/frej/fast-export/issues/240)
+
+To use the plugin, add
+
+    --plugin fix_path

--- a/plugins/fix_path/__init__.py
+++ b/plugins/fix_path/__init__.py
@@ -1,0 +1,9 @@
+def build_filter(args):
+    return Filter()
+
+class Filter:
+
+    def file_data_filter(self, file_data):
+        filename = file_data['filename']
+        if '//' in filename:
+            file_data['filename'] = filename.replace("//", "/")


### PR DESCRIPTION
This plugin sanitizes pathnames containing // (double slash) which will trigger [Empty path component found in input](https://github.com/frej/fast-export/issues/240) issue