### PR TITLE
Allow plugins to modify the committer

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ defined filter methods in the [dos2unix](./plugins/dos2unix) and
 [branch_name_in_commit](./plugins/branch_name_in_commit) plugins.
 
 ```
-commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc, 'revision': revision, 'hg_hash': hg_hash}
+commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc, 'revision': revision, 'hg_hash': hg_hash, 'committer': 'committer'}
 
 def commit_message_filter(self,commit_data):
 ```

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -305,12 +305,16 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
   hg_hash=revsymbol(repo,b"%d" % revision).hex()
 
   if plugins and plugins['commit_message_filters']:
-    commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc, 'revision': revision, 'hg_hash': hg_hash}
+    commit_data = {'branch': branch, 'parents': parents,
+                   'author': author, 'desc': desc,
+                   'revision': revision, 'hg_hash': hg_hash,
+                   'committer': user}
     for filter in plugins['commit_message_filters']:
       filter(commit_data)
     branch = commit_data['branch']
     parents = commit_data['parents']
     author = commit_data['author']
+    user = commit_data['committer']
     desc = commit_data['desc']
 
   if len(parents)==0 and revision != 0:


### PR DESCRIPTION
Plugins have since they were introduced been able to modify the author
of a commit, but not the committer. This patch adds the necessary
support for allowing them to also modify the committer.