### PR TITLE
add requirements.txt with version for python3.5+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+mercurial>=5.2


### PR DESCRIPTION
The hg-fast-export script documents support for python 2.7 with
mercurial 4.6; however, python 2.7 is now officially unsupported.

It took me some time to figure out the requirements, which was just one package. I think a `requirements.txt` is the easiest dependency format for a small package like this.