### PR TITLE
Added ability for file filter plugins to discard files

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ can be modified by any filter. `file_ctx` is the filecontext from the
 mercurial python library.  After all filters have been run, the values
 are used to add the file to the git commit.
 
+To discard a file, set the `"drop_file"` value in its `file_data` to `True`.
+
 Submodules
 ----------
 See README-SUBMODULES.md for how to convert subrepositories into git

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -231,7 +231,9 @@ def export_file_contents(ctx,manifest,files,hgtags,encoding='',plugins={}):
       d=file_data['data']
       filename=file_data['filename']
       file_ctx=file_data['file_ctx']
-
+      if file_data.get('drop_file',False):
+        continue # Plugin dropped the file change
+    
     wr(b'M %s inline %s' % (gitmode(manifest.flags(file)),
                            strip_leading_slash(filename)))
     wr(b'data %d' % len(d)) # had some trouble with size()

--- a/plugins/sync_files_by_prefix/README.md
+++ b/plugins/sync_files_by_prefix/README.md
@@ -1,0 +1,10 @@
+## Whitelist files and folders
+
+To use the plugin, add the command line flag `--plugin file_prefix_whitelist=<prefixes>`.
+<prefixes> is a comma separated list of prefixes. Files with a path that doesn't start
+with any of the prefixes will be discarded. This can create empty commits.
+
+Examples for prefixes:
+ - "src/": This prefix whitelists everything under the src folder.
+ - "src": This prefix whitelists every file or folder beginning with "src"
+ - "a,b": This prefix whitelists every file beginning either with "a" or "b"

--- a/plugins/sync_files_by_prefix/__init__.py
+++ b/plugins/sync_files_by_prefix/__init__.py
@@ -1,0 +1,10 @@
+def build_filter(args):
+    return Filter(args)
+
+class Filter:
+    def __init__(self, args):
+        self.prefixes = args.split(",")
+
+    def file_data_filter(self,file_data):
+        filename = file_data['filename']
+        file_data["drop_file"] = not any([ filename.startswith(x) for x in self.prefixes ])


### PR DESCRIPTION
This pull request allows file data filter plugins to discard files.

For example, if you use this plugin:

```
def build_filter(args):
    return Filter(args)

class Filter:
    def __init__(self, args):
        self.whitelistedPrefixes = args.split(",")

    def file_data_filter(self,file_data):
        filename = file_data['filename']
        file_data["drop_file"] = not any([ filename.startswith(x) for x in self.whitelistedPrefixes ])

```

and call it with the following parameters: `--plugin file_prefix_whitelist='src/'`

only files in the sub-folder `src/` will be included.

This might create some empty commits, but that doesn't cause any issues.