### PR TITLE
Make sure parameter is not None

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -496,7 +496,7 @@ def verify_heads(ui,repo,cache,force,ignore_unnamed_heads,branchesmap):
     if sha1!=c:
       stderr_buffer.write(
         b'Error: Branch [%s] modified outside hg-fast-export:'
-        b'\n%s (repo) != %s (cache)\n' % (b, b'<None>' if sha1 is None else sha1, c)
+        b'\n%s (repo) != %s (cache)\n' % (b, b'<None>' if sha1 is None else sha1, b'None' if c is None else c)
       )
       if not force: return False
 


### PR DESCRIPTION
This fix avoids the exception while making a error  message caused by the parameter
'c' is None when we start first exporting onto non empty git repo,
'c' should be checked like 'sha1'.

Output before fix:
```
$ sh /c/develop/fast-export/hg-fast-export.sh -r ../../hgrepo/TaiyoLaser-hg -e cp932 --fe cp932 -M main
Traceback (most recent call last):
  File "/c/develop/fast-export/hg-fast-export.py", line 729, in <module>
    sys.exit(hg2git(options.repourl,m,options.marksfile,options.mappingfile,
  File "/c/develop/fast-export/hg-fast-export.py", line 548, in hg2git
    if not verify_heads(ui,repo,heads_cache,force,ignore_unnamed_heads,branchesmap):
  File "/c/develop/fast-export/hg-fast-export.py", line 504, in verify_heads
    b'Error: Branch [%s] modified outside hg-fast-export:'
TypeError: %b requires a bytes-like object, or an object that implements __bytes__, not 'NoneType'
fast-import statistics:
...
```

Output after fix:
```
Error: Branch [main] modified outside hg-fast-export:
3b903ad701dc0942c99b1d7ae7ca3d481cab3928 (repo) != None (cache)
fast-import statistics:
...
```