### PR TITLE
Add forward slash to the list of characters to sanitize in sanitize_name

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -266,7 +266,7 @@ def sanitize_name(name,what="branch", mapping={}):
   if not auto_sanitize:
     return mapping.get(name,name)
   n=mapping.get(name,name)
-  p=re.compile(b'([\\[ ~^:?\\\\*]|\.\.)')
+  p=re.compile(b'([\\[ ~^:?\\\\*\/]|\.\.)')
   n=p.sub(b'_', n)
   if n[-1:] in (b'/', b'.'): n=n[:-1]+b'_'
   n=b'/'.join([dot(s) for s in n.split(b'/')])


### PR DESCRIPTION
See Issue #32, I believe this is the correct fix for the underlying issue causing that import failure, or at least it addresses one of the possible branch naming problems that could lead to the issue.