### PR TITLE
hg_hash_in_commit: new plugin to add hg hash to commit message (#275)

### DIFF
--- a/plugins/hg_hash_in_commit/README.md
+++ b/plugins/hg_hash_in_commit/README.md
@@ -1,0 +1,17 @@
+## HG hash in commit message
+
+This plugin will append the mercurial hash to the end of the git
+commit message.  To use the plugin, add to the `hg-fast-export`
+command line options:
+
+    --plugin has_hash_in_commit
+
+By default, the hash is prefixed with `hg:`.  Others can be specified
+as the only option to the plugin.  For example, the prefix `hg: `
+(note the space at the end of the prefix that makes it different from
+the default), use:
+
+    --plugin hg_hash_in_commit="hg: "
+
+At the moment, it is not possible to specify an empty prefix as that
+is interpreted as using the default value.

--- a/plugins/hg_hash_in_commit/__init__.py
+++ b/plugins/hg_hash_in_commit/__init__.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+## Copyright 2022 David Miguel Susano Pinto
+##
+## Permission is hereby granted, free of charge, to any person obtaining
+## a copy of this software and associated documentation files (the
+## "Software"), to deal in the Software without restriction, including
+## without limitation the rights to use, copy, modify, merge, publish,
+## distribute, sublicense, and/or sell copies of the Software, and to
+## permit persons to whom the Software is furnished to do so, subject to
+## the following conditions:
+##
+## The above copyright notice and this permission notice shall be
+## included in all copies or substantial portions of the Software.
+##
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+## EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+## MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+## NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+## LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+## OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+## WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+class HgHashInCommitFilter:
+    def __init__(self, prefix=b"hg:"):
+        self._prefix = prefix
+
+    def commit_message_filter(self, commit_data):
+        assert "hg_hash" in commit_data and "desc" in commit_data
+
+        new_paragraph = b"\n\n"
+        commit_data['desc'] += (new_paragraph
+                                + self._prefix
+                                + commit_data["hg_hash"])
+
+
+def build_filter(opts):
+    # FIXME: having an empty prefix is not supported.
+    #
+    # opts is the string that comes after the plugin name in the
+    # command line arguments to fast-export:
+    #
+    # Use default prefix ("hg:") and opts will be the empty string:
+    #
+    #    --plugin hg_hash_in_commit
+    #
+    # Uses prefix "hg: " (opts is "hg: ").  Note the use of quotes
+    # which are required for the space at the end to be included in
+    # the prefix:
+    #
+    #    --plugin hg_hash_in_commit="hg: "
+    #
+    # The way options for plugins are handled makes it tricky to pass
+    # an empty option value, i.e., how can one set prefix to the empty
+    # string while keeping a default prefix value?
+
+    if not opts:
+        args = []
+    else:
+        args = [opts.encode()]
+    return HgHashInCommitFilter(*args)


### PR DESCRIPTION
As mentioned on issue #275, here's a plugin that adds the hg hash to the end of the git commit message.