### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install sharness
+        run:
+          git clone --depth 1 https://github.com/felipec/sharness.git t/sharness
+      - run: SHARNESS_TEST_SRCDIR=t/sharness t/main.t

--- a/t/.gitignore
+++ b/t/.gitignore
@@ -1,0 +1,1 @@
+/test-results/

--- a/t/main.t
+++ b/t/main.t
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 Felipe Contreras
+#
+
+test_description='Main tests'
+
+. "${SHARNESS_TEST_SRCDIR-/usr/share/sharness}"/sharness.sh || exit 1
+
+check() {
+	echo "$3" > expected &&
+	git -C "$1" show -q --format='%s' "$2" > actual &&
+	test_cmp expected actual
+}
+
+git_clone() {
+	(
+	git init -q "$2" &&
+	cd "$2" &&
+	hg-fast-export.sh --repo "../$1"
+	)
+}
+
+setup() {
+	cat > "$HOME"/.hgrc <<-EOF
+	[ui]
+	username = H G Wells <wells@example.com>
+	EOF
+}
+
+setup
+
+test_expect_success 'basic' '
+	test_when_finished "rm -rf hgrepo gitrepo" &&
+
+	(
+	hg init hgrepo &&
+	cd hgrepo &&
+	echo zero > content &&
+	hg add content &&
+	hg commit -m zero
+	) &&
+
+	git_clone hgrepo gitrepo &&
+	check gitrepo @ zero
+'
+
+test_expect_success 'merge' '
+	test_when_finished "rm -rf hgrepo gitrepo" &&
+
+	(
+	hg init hgrepo &&
+	cd hgrepo &&
+	echo a > content &&
+	echo a > file1 &&
+	hg add content file1 &&
+	hg commit -m "origin" &&
+
+	echo b > content &&
+	echo b > file2 &&
+	hg add file2 &&
+	hg rm file1 &&
+	hg commit -m "right" &&
+
+	hg update -r0 &&
+	echo c > content &&
+	hg commit -m "left" &&
+
+	HGMERGE=true hg merge -r1 &&
+	hg commit -m "merge"
+	) &&
+
+	git_clone hgrepo gitrepo &&
+
+	cat > expected <<-EOF &&
+	left
+	c
+	tree @:
+
+	content
+	file2
+	EOF
+
+	(
+	cd gitrepo
+	git show -q --format='%s' @^ &&
+	git show @:content &&
+	git show @:
+	) > actual &&
+
+	test_cmp expected actual
+'
+
+test_done


### PR DESCRIPTION
It would be useful to have some kind of tests, I personally like [Sharness](http://felipec.github.io/sharness/) (which I recently inherited).

It uses shell scripts and tests are really simple:

```sh
test_expect_success 'foo' '
  hg init
'
```

In this proposal I've added just two tests, but the merge one is already useful to detect issues in some changes I'm working on.

This is what I use in `git-remote-hg` which has quite extensive tests (e.g. [main.t](https://github.com/felipec/git-remote-hg/blob/master/test/main.t)), also what I'm using in my new project `hg-fast-export` (e.g. [main.t](https://github.com/felipec/hg-fast-export/blob/master/t/main.t)), and this is what the Git project uses (e.g. [t0001-init.sh](https://github.com/felipec/hg-fast-export/blob/master/t/main.t)).

It's pretty easy to setup, one can just clone the repository to `t/sharness`, or we can include the whole script which is around 760 lines of code.

It's also easy to setup GitHub actions to run these tests, as you can see I'm setting up an action in this pull request, and the results of one job are [here](https://github.com/felipec/hg-fast-export-frej/actions/runs/4411322327/jobs/7729727359).

It would be nice to have at least some tests, and even nicer if we could share them between projects.