### PR TITLE
Simplifications of get_filechanges

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -74,35 +74,34 @@ def file_mismatch(f1,f2):
   """See if two revisions of a file are not equal."""
   return node.hex(f1)!=node.hex(f2)
 
-def split_dict(dleft,dright,l=[],c=[],r=[],match=file_mismatch):
+def split_dict(dleft,dright,c=[],r=[],match=file_mismatch):
   """Loop over our repository and find all changed and missing files."""
   for left in dleft.keys():
     right=dright.get(left,None)
     if right==None:
-      # we have the file but our parent hasn't: add to left set
-      l.append(left)
+      # we have the file but our parent hasn't: add
+      c.append(left)
     elif match(dleft[left],right) or gitmode(dleft.flags(left))!=gitmode(dright.flags(left)):
-      # we have it but checksums mismatch: add to center set
+      # we have it but checksums mismatch: add
       c.append(left)
   for right in dright.keys():
     left=dleft.get(right,None)
     if left==None:
-      # if parent has file but we don't: add to right set
+      # if parent has file but we don't: remove
       r.append(right)
     # change is already handled when comparing child against parent
-  return l,c,r
+  return c,r
 
 def get_filechanges(repo,revision,parents,mleft):
   """Given some repository and revision, find all changed/deleted files."""
-  l,c,r=[],[],[]
+  c,r=[],[]
   for p in parents:
     if p<0: continue
     mright=repo[p].manifest()
-    l,c,r=split_dict(mleft,mright,l,c,r)
-  l.sort()
+    c,r=split_dict(mleft,mright,c,r)
   c.sort()
   r.sort()
-  return c+l,r
+  return c,r
 
 def get_author(logmessage,committer,authors):
   """As git distincts between author and committer of a patch, try to

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -94,14 +94,14 @@ def split_dict(dleft,dright,c=[],r=[],match=file_mismatch):
 
 def get_filechanges(repo,revision,parents,mleft):
   """Given some repository and revision, find all changed/deleted files."""
-  c,r=[],[]
+  modified,removed=[],[]
   for p in parents:
     if p<0: continue
     mright=repo[p].manifest()
-    c,r=split_dict(mleft,mright,c,r)
-  c.sort()
-  r.sort()
-  return c,r
+    modified,removed=split_dict(mleft,mright,modified,removed)
+  modified.sort()
+  removed.sort()
+  return modified,removed
 
 def get_author(logmessage,committer,authors):
   """As git distincts between author and committer of a patch, try to

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -334,7 +334,7 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
   man=ctx.manifest()
   added,changed,removed,type=[],[],[],''
 
-  if len(parents) == 0:
+  if not parents:
     # first revision: feed in full manifest
     added=files
     type='full'

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -336,8 +336,7 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
 
   if len(parents) == 0:
     # first revision: feed in full manifest
-    added=man.keys()
-    added.sort()
+    added=files
     type='full'
   else:
     wr(b'from %s' % revnum_to_revref(parents[0], old_marks))

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -112,7 +112,6 @@ def get_filechanges(repo,revision,parents,files,mleft):
       # merges where we really need it due to hg's revlog logic
       modified,removed=[],[]
       for p in parents:
-        if p<0: continue
         mright=repo[p].manifest()
         modified,removed=split_dict(mleft,mright,modified,removed)
       modified.sort()

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -73,14 +73,11 @@ def get_filechanges(repo,revision,parents,files):
   """Given some repository and revision, find all changed/deleted files."""
   if not parents:
     # first revision: feed in full manifest
-    modified=files
-    removed=[]
+    return files,[]
   else:
     # take the changes from the first parent
     f=repo.status(parents[0],revision)
-    modified=f.modified + f.added
-    removed=f.removed
-  return modified,removed
+    return f.modified+f.added,f.removed
 
 def get_author(logmessage,committer,authors):
   """As git distincts between author and committer of a patch, try to

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -111,9 +111,8 @@ def get_filechanges(repo,revision,parents,files,mleft):
       # for many files comparing checksums is expensive so only do it for
       # merges where we really need it due to hg's revlog logic
       modified,removed=[],[]
-      for p in parents:
-        mright=repo[p].manifest()
-        modified,removed=split_dict(mleft,mright,modified,removed)
+      mright=repo[parents[0]].manifest()
+      modified,removed=split_dict(mleft,mright,modified,removed)
       modified.sort()
       removed.sort()
   return modified,removed


### PR DESCRIPTION
This code hasn't been touched in decades, but most of it is not necessary. In [git-remote-hg](https://github.com/felipec/git-remote-hg/blob/master/git-remote-hg#L316) we've been using a simplified version of `get_filechanges`+`split_dict` for many years (maybe a decade?).

All that is needed is to compare the files of the new commit with the ones of the first parent.

To test the different versions of the code I wrote a benchmarking tool [filechanges-perf](https://github.com/felipec/hg-fast-export/blob/tool/filechanges-perf/tools/filechanges-perf). The new version of the code is reliably faster, and produces the same resulting repos. In the case of `hg` it's almost twice as fast.

I tested with `hg`, `mozilla-central`, and `hg-git`:

```
hg '0:10000':
3cd697c5eccb477a29f9570d2b829d8ee807b0cc
0: 46.59
3cd697c5eccb477a29f9570d2b829d8ee807b0cc
1: 25.71

mozilla-central '0:10000':
c027d5531d03c29b879ca69f58d3e8997e8ae7e8
0: 113.60
c027d5531d03c29b879ca69f58d3e8997e8ae7e8
1: 102.37

hg-git '0:tip':
a4c5b8d1e35739501a7141b844fc4eaea57b6c5a
0: 3.25
a4c5b8d1e35739501a7141b844fc4eaea57b6c5a
1: 2.63
```

Same output, faster execution, and simpler code.