### PR TITLE
Make pluginloader use importlib instead imp

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,9 @@ first time.
 System Requirements
 -------------------
 
-This project depends on Python 2.7 or 3.5+, and the Mercurial >= 4.6
-package (>= 5.2, if Python 3.5+). If Python is not installed, install
-it before proceeding. The Mercurial package can be installed with `pip
-install mercurial`.
+This project depends on Python 3.5+, and the Mercurial >= 5.2 package.
+If Python is not installed, install it before proceeding. The Mercurial
+package can be installed with `pip install mercurial`.
 
 On windows the bash that comes with "Git for Windows" is known to work
 well.
@@ -110,8 +109,8 @@ branch/tag names. In the future -n will become the default, but in
 order to not break existing incremental conversions, the default
 remains with the old behavior.
 
-By default, the `default` mercurial branch is renamed to the `master` 
-branch on git. If your mercurial repo contains both `default` and 
+By default, the `default` mercurial branch is renamed to the `master`
+branch on git. If your mercurial repo contains both `default` and
 `master` branches, you'll need to override this behavior. Use
 `-M <newName>` to specify what name to give the `default` branch.
 

--- a/pluginloader/__init__.py
+++ b/pluginloader/__init__.py
@@ -1,5 +1,6 @@
 import os
-import imp
+import importlib.machinery
+import importlib.util
 PluginFolder = os.path.join(os.path.dirname(os.path.realpath(__file__)),"..","plugins")
 MainModule = "__init__"
 
@@ -11,9 +12,12 @@ def get_plugin(name, plugin_path):
         location = os.path.join(dir, name)
         if not os.path.isdir(location) or not MainModule + ".py" in os.listdir(location):
             continue
-        info = imp.find_module(MainModule, [location])
-        return {"name": name, "info": info, "path": location}
+        spec = importlib.machinery.PathFinder.find_spec(MainModule, [location])
+        return {"name": name, "spec": spec, "path": location}
     raise Exception("Could not find plugin with name " + name)
 
 def load_plugin(plugin):
-    return imp.load_module(MainModule, *plugin["info"])
+    spec = plugin["spec"]
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module


### PR DESCRIPTION
Python 3.12 has removed `imp` and it's recommended to use `importlib` instead.

Closes #310.