### PR TITLE
Run tests with multiple Python versions

### DIFF
--- a/.github/requirements-earliest.txt
+++ b/.github/requirements-earliest.txt
@@ -1,0 +1,1 @@
+mercurial==5.2

--- a/.github/requirements-latest.txt
+++ b/.github/requirements-latest.txt
@@ -1,0 +1,2 @@
+mercurial
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,70 @@ on:
     branches: [master]
 
 jobs:
-  test:
-    name: Run test suite
+  test-earliest:
+    name: Run test suite on the earliest supported Python version
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout repository
+        with:
+          fetch-depth: 1
+          submodules: 'recursive'
+      - uses: actions/setup-python@v5
+        id: earliest
+        with:
+          python-version: '3.7.x'
+          check-latest: true
+          cache: 'pip'
+          cache-dependency-path: '**/requirements-earliest.txt'
+
+      - name: Install dependencies
+        run: |
+            python -m pip install --upgrade pip
+            pip install -r .github/requirements-earliest.txt
+
+      - name: Report selected versions
+        run: |
+          echo Selected '${{ steps.earliest.outputs.python-version }}'
+          ./hg-fast-export.sh --debug
+
+      - name: Run tests on earliest supported Python version
+        run: make -C t
+
+  test-latest:
+    name: Run test suite on the latest supported python version
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout repository
+        with:
+          fetch-depth: 1
+          submodules: 'recursive'
+      - uses: actions/setup-python@v5
+        id: latest
+        with:
+          python-version: '3.x'
+          check-latest: true
+          cache: 'pip'
+          cache-dependency-path: '**/requirements-latest.txt'
+
+      - name: Install dependencies
+        run: |
+            python -m pip install --upgrade pip
+            pip install -r .github/requirements-latest.txt
+
+      - name: Report selected version
+        run: |
+          echo Selected '${{ steps.latest.outputs.python-version }}'
+          ./hg-fast-export.sh --debug
+
+      - name: Run tests on 3.x
+        run: make -C t
+
+  code-quality:
+    name: Run code quality checks
     runs-on: ubuntu-latest
 
     steps:
@@ -18,9 +80,6 @@ jobs:
       with:
         fetch-depth: 1
         submodules: 'recursive'
-
-    - name: Run tests
-      run: make -C t
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ first time.
 System Requirements
 -------------------
 
-This project depends on Python 3.5+, and the Mercurial >= 5.2 package.
-If Python is not installed, install it before proceeding. The Mercurial
-package can be installed with `pip install mercurial`.
+This project depends on Python (>=3.7) and the Mercurial package (>=
+5.2).  If Python is not installed, install it before proceeding. The
+Mercurial package can be installed with `pip install mercurial`.
 
 On windows the bash that comes with "Git for Windows" is known to work
 well.

--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -86,6 +86,14 @@ case "$1" in
       echo ""
       echo "$LONG_USAGE"
       exit 0
+      ;;
+
+    --debug)
+      echo -n "Using Python: "
+      "${PYTHON}" --version
+      echo -n "Using Mercurial: "
+      hg --version
+      exit 0
 esac
 
 IS_BARE=$(git rev-parse --is-bare-repository) \

--- a/hg-fast-export.sh
+++ b/hg-fast-export.sh
@@ -45,6 +45,14 @@ if [ -z "${PYTHON}" ]; then
     exit 1
 fi
 
+"${PYTHON}" -c 'import sys; exit(sys.version_info.major==3 and sys.version_info.minor >= 7)'
+
+if [ $? -eq 0 ]; then
+    echo "Could not find an interpreter for a supported Python version (>= 3.7)" \
+        "Please use the 'PYTHON' environment variable to specify the interpreter to use."
+    exit 1
+fi
+
 USAGE="[--quiet] [-r <repo>] [--force] [--ignore-unnamed-heads] [-m <max>] [-s] [--hgtags] [-A <file>] [-B <file>] [-T <file>] [-M <name>] [-o <name>] [--hg-hash] [-e <encoding>]"
 LONG_USAGE="Import hg repository <repo> up to either tip or <max>
 If <repo> is omitted, use last hg repository as obtained from state file,


### PR DESCRIPTION
Run the CI tests with both the earliest supported Python version and the latest stable release.

The intent is to quickly notice when new features require adjusting the oldest supported Python version and also detect when the latest stable version breaks old code (as when 3.12 removed `imp` and we switched to `importlib` in #311).