### PR TITLE
Fix escape in regular expression

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -228,7 +228,7 @@ def sanitize_name(name,what="branch", mapping={}):
   if not auto_sanitize:
     return mapping.get(name,name)
   n=mapping.get(name,name)
-  p=re.compile(b'([\\[ ~^:?\\\\*]|\.\.)')
+  p=re.compile(b'([\\[ ~^:?\\\\*]|\\.\\.)')
   n=p.sub(b'_', n)
   if n[-1:] in (b'/', b'.'): n=n[:-1]+b'_'
   n=b'/'.join([dot(s) for s in n.split(b'/')])


### PR DESCRIPTION
The string used to create the regular expression should contain literal backslashes, so they need to be escaped. Python 12 warns about it:

```
hg-fast-export.py:231: SyntaxWarning: invalid escape sequence '\.'
```