### PR TITLE
added time and timezone into commit_data for commit_message_filter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ defined filter methods in the [dos2unix](./plugins/dos2unix) and
 [branch_name_in_commit](./plugins/branch_name_in_commit) plugins.
 
 ```
-commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc, 'revision': revision, 'hg_hash': hg_hash, 'committer': 'committer', 'extra': extra}
+commit_data = {'branch': branch, 'parents': parents, 'author': author, 'desc': desc, 'revision': revision, 'hg_hash': hg_hash, 'committer': 'committer', 'extra': extra, 'time': time, 'timezone': timezone}
 
 def commit_message_filter(self,commit_data):
 ```

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -274,7 +274,8 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
     commit_data = {'branch': branch, 'parents': parents,
                    'author': author, 'desc': desc,
                    'revision': revision, 'hg_hash': hg_hash,
-                   'committer': user, 'extra': extra}
+                   'committer': user, 'extra': extra,
+                   'time': time, 'timezone': timezone}
     for filter in plugins['commit_message_filters']:
       filter(commit_data)
     branch = commit_data['branch']
@@ -282,6 +283,8 @@ def export_commit(ui,repo,revision,old_marks,max,count,authors,
     author = commit_data['author']
     user = commit_data['committer']
     desc = commit_data['desc'] + b'\n'
+    time = commit_data['time']
+    timezone = commit_data['timezone']
 
   if len(parents)==0 and revision != 0:
     wr(b'reset refs/heads/%s' % branch)


### PR DESCRIPTION
Hi!

This is needed to create a plugin which uniqualizes git commit hashes when there are grafts in numerous mercurial branches exist.

Here is a demo which makes two git commits out of three in mecrial:
```
#!/bin/bash
# mercurial actions
rm -rf test.hg
mkdir test.hg
cd test.hg
hg init
echo line1 > file1
hg add
hg com -m 'initial commit'
hg branch branch1
echo line2 >> file1
hg com -m 'line2 added'
hg up default
hg branch branch2
hg graft -r 1
hg up default
hg log

cd ..
# git init
rm -rf test.git
mkdir test.git
cd test.git
git init

# migration
../fast-export/hg-fast-export.sh -r ../test.hg # --plugin unique_hash=desc

# check results
git log --all
cat .git/hg2git-marks
while read line; do echo && git log `echo $line|cut -d ' ' -f 2`; done < .git/hg2git-marks
```

The plugin code:
```
import hashlib

def build_filter(args):
    return UniqueFilter(args)

class UniqueFilter:
    def __init__(self, args):
        self.commits = {}
        self.modify = args

    def commit_message_filter(self, commit_data):
        key = self.make_key(commit_data)
        while key in self.commits:
            self.make_unique(commit_data)
            key = self.make_key(commit_data)
        self.commits[key] = True

    def make_key(self, commit_data):
        return hashlib.sha1(b'%s|%s|%d|%s' % (commit_data['author'], commit_data['desc'], commit_data['time'], commit_data['timezone'])).hexdigest()
    
    def make_unique(self, commit_data):
        if self.modify == 'desc':
            commit_data['desc'] += b' '
        else:
            commit_data['time'] += 1
```
Regards, Maxim