### PR TITLE
Converted from in commit message

### DIFF
--- a/plugins/converted_from_in_commit/README.md
+++ b/plugins/converted_from_in_commit/README.md
@@ -6,7 +6,7 @@ This can be useful, for example, to remove old, irrelevant history.
 To preserve original commit hashes during this process,
 you can enable the `saverev` flag:
 ```
-hg convert --config hg.convert.saverev=True ...
+hg convert --config convert.hg.saverev=True ...
 ```
 
 After such a conversion, the original hashes are

--- a/plugins/converted_from_in_commit/README.md
+++ b/plugins/converted_from_in_commit/README.md
@@ -1,0 +1,23 @@
+## Convert Revision in Commit Message
+
+When converting a Mercurial repository, you may first convert it
+from an original source before migrating it to Git.
+This can be useful, for example, to remove old, irrelevant history.
+To preserve original commit hashes during this process,
+you can enable the `saverev` flag:
+```
+hg convert --config hg.convert.saverev=True ...
+```
+
+After such a conversion, the original hashes are
+stored in `["extra"]["convert_revision"]`.
+This plugin extracts those hashes and appends them to commit messages.
+The resulting commit messages will look like this:
+```
+<original message>
+
+Converted From: <convert_revision>
+```
+
+To use the plugin, add `--plugin converted_from_in_commit`.
+

--- a/plugins/converted_from_in_commit/__init__.py
+++ b/plugins/converted_from_in_commit/__init__.py
@@ -1,0 +1,14 @@
+def build_filter(args):
+    return Filter(args)
+
+class Filter:
+    def __init__(self, args):
+        pass
+
+    def commit_message_filter(self, commit_data):
+        cvt = commit_data['extra'].get(b'convert_revision')
+        if cvt is not None:
+            commit_data['desc'] = (
+                    commit_data['desc'] + b'\n\nConverted From: ' + cvt 
+            )
+


### PR DESCRIPTION
Just a little plugin I've found useful for preserving revision hashes after this (rather unusual) conversion chain:
* take original mercurial repo;
* `hg convert --config convert.hg.saverev=True ...` - maybe wipe some old history, or smth like that, preserving original hashes in `extra`;
* `hg-fast-export.sh ... --plugin converted_from_in_commit` - convert to git, appending original hashes from `extra` to commit messages.