### PR TITLE
Fix "Warn if one of the marks, mapping, or heads files are empty"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   test-earliest:
     name: Run test suite on the earliest supported Python version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -539,7 +539,7 @@ def hg2git(repourl,m,marksfile,mappingfile,headsfile,tipfile,
   if len(state_cache) != 0:
     for (name, data) in [(marksfile, old_marks),
                          (mappingfile, mapping_cache),
-                         (headsfile, state_cache)]:
+                         (headsfile, heads_cache)]:
       check_cache(name, data)
 
   ui,repo=setup_repo(repourl)


### PR DESCRIPTION
The commit "Warn if one of the marks, mapping, or heads files are empty" (7224e420a75f) mixed up the state and heads caches and reported that the heads cache was empty if the state case was. Error found by Shun-ichi Goto.

Closes #338