### PR TITLE
Support Mercurial 7.2

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -488,7 +488,9 @@ def branchtip(repo, heads):
 
 def verify_heads(ui,repo,cache,force,ignore_unnamed_heads,branchesmap):
   branches={}
-  for bn, heads in repo.branchmap().iteritems():
+
+  for bn in repo.branchmap():
+    heads = repo.branchmap().branchheads(bn)
     branches[bn] = branchtip(repo, heads)
   l=[(-repo.changelog.rev(n), n, t) for t, n in branches.items()]
   l.sort()

--- a/hg2git.py
+++ b/hg2git.py
@@ -31,6 +31,14 @@ def set_origin_name(name):
 
 def setup_repo(url):
   try:
+    # Mercurial >= 7.2 requires explicit initialization for largefile
+    # support to work.
+    from mercurial import initialization
+    initialization.init()
+  except ImportError:
+    pass
+
+  try:
     myui=ui.ui(interactive=False)
   except TypeError:
     myui=ui.ui()


### PR DESCRIPTION
In Mercurial 7.2 the iteritems() method of the branchmap has been removed. Switch to iterating over the branches and then fetching heads by the branchheads() method.

Closes #348