### PR TITLE
Fix-Check for heads before assigning branch tips

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -491,7 +491,8 @@ def verify_heads(ui,repo,cache,force,ignore_unnamed_heads,branchesmap):
 
   for bn in repo.branchmap():
     heads = repo.branchmap().branchheads(bn)
-    branches[bn] = branchtip(repo, heads)
+    if heads:
+      branches[bn] = branchtip(repo, heads)
   l=[(-repo.changelog.rev(n), n, t) for t, n in branches.items()]
   l.sort()
 


### PR DESCRIPTION
branchheads() reports an empty list for some branches which result in:
```
Traceback (most recent call last):
  File "/home/john/git/fast-export/hg-fast-export.py", line 739, in <module>
    sys.exit(hg2git(options.repourl,m,options.marksfile,options.mappingfile,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/john/git/fast-export/hg-fast-export.py", line 556, in hg2git
    if not verify_heads(ui,repo,heads_cache,force,ignore_unnamed_heads,branchesmap):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/john/git/fast-export/hg-fast-export.py", line 494, in verify_heads
    branches[bn] = branchtip(repo, heads)
                   ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/john/git/fast-export/hg-fast-export.py", line 482, in branchtip
    tip = heads[-1]
          ~~~~~^^^^
IndexError: list index out of range

```