### PR TITLE
Fix: Largefile with CRLF in .hglf file

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -172,7 +172,7 @@ def largefile_orig_name(filename):
 
 def largefile_data(ctx, file, filename):
   lf_file_ctx=ctx.filectx(file)
-  lf_hash=lf_file_ctx.data().strip(b'\n')
+  lf_hash=lf_file_ctx.data().strip()
   sys.stderr.write("Detected large file hash %s\n" % lf_hash.decode())
   #should detect where the large files are located
   file_with_data = lfutil.findfile(ctx.repo(), lf_hash)


### PR DESCRIPTION
Files in .hglf could contain CRLF instead of just LF line endings. The largefile export was confused by this while reading the hash.

Fixed by stripping all whitespaces from the hash.