### PR TITLE
Fix: Handle invalid characters in branch names for Windows and Git compatibility

### DIFF
--- a/hg-fast-export.py
+++ b/hg-fast-export.py
@@ -264,7 +264,8 @@ def sanitize_name(name,what="branch", mapping={}):
   if not auto_sanitize:
     return mapping.get(name,name)
   n=mapping.get(name,name)
-  p=re.compile(b'([\\[ ~^:?\\\\*]|\\.\\.)')
+  # Include Windows-invalid characters and Git-invalid characters: < > : " / \ | ? * ' !
+  p=re.compile(b'([\\[ ~^:?\\\\*\"><|!' + b"'" + b']|\\.\\.)')
   n=p.sub(b'_', n)
   if n[-1:] in (b'/', b'.'): n=n[:-1]+b'_'
   n=b'/'.join([dot(s) for s in n.split(b'/')])

--- a/hg2git.py
+++ b/hg2git.py
@@ -123,7 +123,7 @@ def save_cache(filename,cache):
 def get_git_sha1(name,type='heads'):
   try:
     # use git-rev-parse to support packed refs
-    ref="refs/%s/%s" % (type,name.decode('utf8'))
+    ref="refs/%s/%s" % (type,name.decode('utf8', errors='replace'))
     l=subprocess.check_output(["git", "rev-parse", "--verify",
                                "--quiet", ref.encode('utf8')])
     if l == None or len(l) == 0:


### PR DESCRIPTION
Branch names containing certain characters (like <, >, :, ", /, \, |, ?, *, ', !) cause issues on Windows file systems and with Git refs. This fix extends the sanitization regex in hg-fast-export.py to handle Windows-specific invalid characters that were previously missing.
Additionally, adds error handling in hg2git.py to gracefully handle branch names with invalid UTF-8 characters by using errors='replace' instead of crashing.